### PR TITLE
refactor: 💡 remove offender from longpostcode add prefilled aid

### DIFF
--- a/src/components/registration/registrationData.js
+++ b/src/components/registration/registrationData.js
@@ -552,7 +552,7 @@ export default {
 		useInformal: false,
 		overline: 'Beratung für Angehörige von Straffälligen',
 		showEmail: true,
-		showPostCode: true
+		showPostCode: false
 	},
 	aids: {
 		consultingType: '12',

--- a/src/resources/ts/config.ts
+++ b/src/resources/ts/config.ts
@@ -55,6 +55,8 @@ export const config = {
 		sessionAssign: tld + '/service/users/sessions',
 		passwordReset: tld + '/service/users/password/change',
 		getMonitoring: tld + '/service/users/sessions',
+		registrationOffenderRedirect:
+			'/registration.straffaelligkeit.html?aid=',
 		registrationRehabilitationRedirect:
 			'/registration.kinder-reha.html?aid=',
 		registrationKreuzbundRedirect:

--- a/src/resources/ts/helpers/resorts.ts
+++ b/src/resources/ts/helpers/resorts.ts
@@ -37,14 +37,14 @@ export const isGenericConsultingType = (currentType: number): Boolean => {
 export const hasConsultingTypeLongPostcodeValidation = (
 	consultingType: number = getConsultingTypeFromRegistration()
 ): Boolean => {
-	const typesUsingLongPostcodeValidation = ['11', '12', '17'];
+	const typesUsingLongPostcodeValidation = ['12', '17'];
 	return typesUsingLongPostcodeValidation.includes(consultingType.toString());
 };
 
 export const hasPreselectedAgencyFallback = (
 	consultingType: number = getConsultingTypeFromRegistration()
 ): Boolean => {
-	const typesWithPreselectedAgencyFallback = ['13', '15'];
+	const typesWithPreselectedAgencyFallback = ['11', '13', '15'];
 	return typesWithPreselectedAgencyFallback.includes(
 		consultingType.toString()
 	);
@@ -84,6 +84,7 @@ export const POSTCODE_FALLBACK_LINK = {
 };
 
 export const AGENCY_FALLBACK_LINK = {
+	11: config.endpoints.registrationOffenderRedirect,
 	13: config.endpoints.registrationRehabilitationRedirect,
 	15: config.endpoints.registrationKreuzbundRedirect
 };


### PR DESCRIPTION
## Proposed Changes

  - remove offender registration (consulting type 11) from long-postcode-validation
  - add prefilled aid functionality to offender registration

