### PR TITLE
feat(webpack-dev-server): 🎸 history fallback rewrites and caritas.local host

### DIFF
--- a/config/webpackDevServer.config.js
+++ b/config/webpackDevServer.config.js
@@ -98,6 +98,10 @@ module.exports = function (proxy, allowedHost) {
       // See https://github.com/facebook/create-react-app/issues/387.
       disableDotRule: true,
       index: paths.publicUrlOrPath,
+      rewrites: [
+        { from: /^\/$/, to: '/login.html' },
+        { from: /^\/.+/, to: '/beratung-hilfe.html' },
+      ]
     },
     public: allowedHost,
     // `proxy` is run between `before` and `after` `webpack-dev-server` hooks

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "standard-version": "9.0.0"
   },
   "scripts": {
-    "start": "node scripts/start.js",
+    "start": "HOST=caritas.local node scripts/start.js",
     "build": "node scripts/build.js",
     "test": "node scripts/test.js"
   },


### PR DESCRIPTION
## Proposed Changes

Developer Experience:

  - Let `npm start` open `http://caritas.local:9000` in the browser
  - Path `/` shows the `login.html`
  - All non-existing paths are rewritten to `beratung-hilfe.html` which makes it so that client-side React Router paths can be reloaded (F5 or browser restart)
