### PR TITLE
feat: refresh keycloak access token until refresh token expires

### DIFF
--- a/cypress/fixtures/auth.token.json
+++ b/cypress/fixtures/auth.token.json
@@ -1,7 +1,7 @@
 {
 	"access_token": "access_token",
-	"expires_in": 43200000,
-	"refresh_expires_in": 900,
+	"expires_in": 600,
+	"refresh_expires_in": 1800,
 	"refresh_token": "refresh_token",
 	"token_type": "bearer",
 	"not-before-policy": 0,

--- a/cypress/integration/tokens.spec.ts
+++ b/cypress/integration/tokens.spec.ts
@@ -1,0 +1,110 @@
+import { RENEW_BEFORE_EXPIRY_TIME } from '../../src/components/auth/auth';
+import { getTokenExpiryFromLocalStorage } from '../../src/components/sessionCookie/accessSessionLocalStorage';
+
+const waitForTokenProcessing = () => {
+	// TODO: don't arbitrarily wait for token to be processed, find some
+	// way to cleanly determine that the token was processed instead.
+	// possible canidates are spying on `localStorage` or `setTimeout`
+	return cy.wait(500); // eslint-disable-line cypress/no-unnecessary-waiting
+};
+
+describe('Keycloak Tokens', () => {
+	let authTokenJson;
+	before(() => {
+		cy.fixture('auth.token.json').then((fixture) => {
+			authTokenJson = fixture;
+		});
+	});
+
+	it('should get and store tokens and expiry time on login', () => {
+		cy.caritasMockedLogin();
+
+		cy.get('#appRoot').then(() => {
+			cy.getCookie('keycloak').should('exist');
+			cy.getCookie('refreshToken').should('exist');
+
+			const tokenExpiry = getTokenExpiryFromLocalStorage();
+			expect(tokenExpiry.validUntil).to.exist;
+			expect(tokenExpiry.refreshValidUntil).to.exist;
+		});
+	});
+
+	it('should keep refreshing access token before it expires', () => {
+		cy.clock();
+		cy.caritasMockedLogin();
+
+		for (let check = 0; check < 3; check++) {
+			waitForTokenProcessing();
+
+			cy.tick(authTokenJson.expires_in * 1000 - RENEW_BEFORE_EXPIRY_TIME);
+			cy.wait('@authToken').then((interception) => {
+				expect(interception.request.body).to.include(
+					'grant_type=refresh_token'
+				);
+			});
+		}
+	});
+
+	it('should refresh the access token if its expired when loading the app', () => {
+		cy.clock();
+		cy.caritasMockedLogin();
+
+		cy.clock().then((clock) => {
+			clock.restore();
+		});
+		cy.clock(authTokenJson.expires_in * 1000 + 1);
+		cy.reload();
+		cy.get('#appRoot');
+
+		cy.wait('@authToken').then((interception) => {
+			expect(interception.request.body).to.include(
+				'grant_type=refresh_token'
+			);
+		});
+
+		cy.tick(1000); // logout() call uses setTimeout
+		cy.get('#appRoot').should('exist');
+	});
+
+	it('should logout if refresh token is already expired when loading the app', () => {
+		cy.clock();
+		cy.caritasMockedLogin();
+
+		cy.clock().then((clock) => {
+			clock.restore();
+		});
+		cy.clock(authTokenJson.refresh_expires_in * 1000 + 1);
+		cy.reload();
+		cy.get('#appRoot');
+		waitForTokenProcessing();
+
+		cy.tick(1000); // logout() call uses setTimeout
+		cy.get('#loginRoot').should('exist');
+	});
+
+	it('should logout if refresh token is expired while the app is loaded', () => {
+		cy.clock();
+		cy.caritasMockedLogin();
+		waitForTokenProcessing();
+
+		cy.tick(authTokenJson.refresh_expires_in * 1000 + 1);
+		waitForTokenProcessing();
+
+		cy.tick(1000); // logout() call uses setTimeout
+		cy.get('#loginRoot').should('exist');
+	});
+
+	it('should not logout if refresh token is expired but access token is still valid', () => {
+		cy.clock();
+		cy.caritasMockedLogin({
+			auth: { expires_in: 1800, refresh_expires_in: 600 }
+		});
+
+		waitForTokenProcessing();
+		cy.tick(600 * 1000);
+		waitForTokenProcessing();
+
+		cy.tick(1000); // logout() call uses setTimeout
+		cy.get('#loginRoot').should('not.exist');
+	});
+});

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -24,8 +24,8 @@ afterEach(() => {
 	// - https://github.com/cypress-io/cypress/issues/9170
 	// - https://github.com/cypress-io/cypress/issues/9362
 	// - https://github.com/cypress-io/cypress/issues/8926
-	cy.clearCookies();
 	cy.window().then((win) => (win.location.href = 'about:blank'));
+	cy.clearCookies();
 });
 
 Cypress.Commands.add(
@@ -81,7 +81,7 @@ Cypress.Commands.add(
 		cy.intercept('GET', config.endpoints.userSessions, {
 			fixture: 'service.users.sessions.askers.json'
 		});
-		cy.intercept('GET', config.endpoints.liveservice, {
+		cy.intercept('GET', `${config.endpoints.liveservice}/**/*`, {
 			fixture: 'service.live.info.json'
 		});
 		cy.intercept('POST', config.endpoints.rocketchatAccessToken, {
@@ -102,6 +102,6 @@ Cypress.Commands.add(
 		});
 		cy.get('.button__primary').click();
 		cy.wait('@authToken');
-		cy.get('#appRoot');
+		cy.get('#appRoot').should('exist');
 	}
 );

--- a/src/components/app/app.tsx
+++ b/src/components/app/app.tsx
@@ -22,6 +22,7 @@ import {
 import { ContextProvider } from '../../globalState/state';
 import { getUserData } from '../apiWrapper';
 import { Loading } from './Loading';
+import { handleTokenRefresh } from '../auth/auth';
 import { logout } from '../logout/logout';
 import '../../resources/styles/styles';
 import './app.styles';
@@ -75,20 +76,22 @@ export const App: React.FC = () => {
 
 	if (!userDataRequested) {
 		setUserDataRequested(true);
-		getUserData()
-			.then((userProfileData: UserDataInterface) => {
-				// set informal / formal cookie depending on the given userdata
-				setTokenInCookie(
-					'useInformal',
-					!userProfileData.formalLanguage ? '1' : ''
-				);
-				setUserData(userProfileData);
-				setAppReady(true);
-			})
-			.catch((error) => {
-				window.location.href = config.endpoints.logoutRedirect;
-				console.log(error);
-			});
+		handleTokenRefresh().then(() => {
+			getUserData()
+				.then((userProfileData: UserDataInterface) => {
+					// set informal / formal cookie depending on the given userdata
+					setTokenInCookie(
+						'useInformal',
+						!userProfileData.formalLanguage ? '1' : ''
+					);
+					setUserData(userProfileData);
+					setAppReady(true);
+				})
+				.catch((error) => {
+					window.location.href = config.endpoints.logoutRedirect;
+					console.log(error);
+				});
+		});
 	}
 
 	useEffect(() => {

--- a/src/components/auth/auth.ts
+++ b/src/components/auth/auth.ts
@@ -3,21 +3,26 @@ import { LoginData } from '../registration/autoLogin';
 import { setTokenInCookie } from '../sessionCookie/accessSessionCookie';
 import {
 	getTokenExpiryFromLocalStorage,
-	setAccessTokenExpiryInLocalStorage,
-	setRefreshTokenExpiryInLocalStorage
+	setTokenExpiryInLocalStorage
 } from '../sessionCookie/accessSessionLocalStorage';
 import { refreshKeycloakAccessToken } from '../sessionCookie/refreshKeycloakAccessToken';
 
-export const RENEW_BEFORE_EXPIRY_TIME = 10 * 1000; // seconds
+export const RENEW_BEFORE_EXPIRY_IN_MS = 10 * 1000; // seconds
 
 export const setTokens = (data: LoginData) => {
 	if (data.access_token) {
 		setTokenInCookie('keycloak', data.access_token);
-		setAccessTokenExpiryInLocalStorage(data.expires_in);
+		setTokenExpiryInLocalStorage(
+			'auth.access_token_valid_until',
+			data.expires_in
+		);
 	}
 	if (data.refresh_token) {
 		setTokenInCookie('refreshToken', data.refresh_token);
-		setRefreshTokenExpiryInLocalStorage(data.refresh_expires_in);
+		setTokenExpiryInLocalStorage(
+			'auth.refresh_token_valid_until',
+			data.refresh_expires_in
+		);
 	}
 };
 
@@ -26,8 +31,8 @@ const refreshTokens = (): Promise<void> => {
 	const tokenExpiry = getTokenExpiryFromLocalStorage();
 
 	if (
-		tokenExpiry.refreshValidUntil <=
-		currentTime - RENEW_BEFORE_EXPIRY_TIME
+		tokenExpiry.refreshTokenValidUntilTime <=
+		currentTime - RENEW_BEFORE_EXPIRY_IN_MS
 	) {
 		logout(true);
 		return Promise.resolve();
@@ -38,28 +43,34 @@ const refreshTokens = (): Promise<void> => {
 	});
 };
 
-const startTimers = (
-	tokenValidMs: number,
-	tokenRefreshExpiredTimeout: number
-) => {
-	const tokenRefreshAccessTokenInterval =
-		tokenValidMs - RENEW_BEFORE_EXPIRY_TIME;
+const startTimers = ({
+	accessTokenValidInMs,
+	refreshTokenValidInMs
+}: {
+	accessTokenValidInMs: number;
+	refreshTokenValidInMs: number;
+}) => {
+	const accessTokenRefreshIntervalInMs =
+		accessTokenValidInMs - RENEW_BEFORE_EXPIRY_IN_MS;
 
 	let refreshInterval;
-	if (tokenRefreshAccessTokenInterval > 0) {
+	// just a sanity check so that we don't accidentally register an endless loop
+	if (accessTokenRefreshIntervalInMs > 0) {
 		refreshInterval = window.setInterval(() => {
 			refreshTokens();
-		}, tokenRefreshAccessTokenInterval);
+		}, accessTokenRefreshIntervalInMs);
 	}
 
-	if (tokenValidMs <= tokenRefreshExpiredTimeout) {
+	if (refreshTokenValidInMs > accessTokenValidInMs) {
+		// when refresh token is longer valid than access token we need to
+		// logout if the refresh token expires
 		window.setTimeout(() => {
 			if (refreshInterval) {
 				window.clearInterval(refreshInterval);
 			}
 
 			logout(true);
-		}, tokenRefreshExpiredTimeout);
+		}, refreshTokenValidInMs);
 	}
 };
 
@@ -67,21 +78,31 @@ export const handleTokenRefresh = (): Promise<void> => {
 	return new Promise((resolve) => {
 		const currentTime = new Date().getTime();
 		const tokenExpiry = getTokenExpiryFromLocalStorage();
-		const tokenValidMs = tokenExpiry.validUntil - currentTime;
+		const accessTokenValidInMs =
+			tokenExpiry.accessTokenValidUntilTime - currentTime;
 
-		const tokenRefreshExpiredTimeout =
-			tokenExpiry.refreshValidUntil - currentTime;
+		const refreshTokenValidInMs =
+			tokenExpiry.refreshTokenValidUntilTime - currentTime;
 
-		if (tokenRefreshExpiredTimeout <= 0) {
+		if (refreshTokenValidInMs <= 0 && accessTokenValidInMs <= 0) {
+			// access token and refresh token no longer valid, logout
 			logout(true);
 			resolve();
-		} else if (tokenValidMs <= 0) {
+		} else if (accessTokenValidInMs <= 0) {
+			// access token no longer valid but refresh token still valid, refresh tokens
 			refreshTokens().then(() => {
-				startTimers(tokenValidMs, tokenRefreshExpiredTimeout);
+				startTimers({
+					accessTokenValidInMs,
+					refreshTokenValidInMs
+				});
 				resolve();
 			});
 		} else {
-			startTimers(tokenValidMs, tokenRefreshExpiredTimeout);
+			// access token and refresh token still valid, just start the timers
+			startTimers({
+				accessTokenValidInMs,
+				refreshTokenValidInMs
+			});
 			resolve();
 		}
 	});

--- a/src/components/auth/auth.ts
+++ b/src/components/auth/auth.ts
@@ -1,0 +1,88 @@
+import { logout } from '../logout/logout';
+import { LoginData } from '../registration/autoLogin';
+import { setTokenInCookie } from '../sessionCookie/accessSessionCookie';
+import {
+	getTokenExpiryFromLocalStorage,
+	setAccessTokenExpiryInLocalStorage,
+	setRefreshTokenExpiryInLocalStorage
+} from '../sessionCookie/accessSessionLocalStorage';
+import { refreshKeycloakAccessToken } from '../sessionCookie/refreshKeycloakAccessToken';
+
+export const RENEW_BEFORE_EXPIRY_TIME = 10 * 1000; // seconds
+
+export const setTokens = (data: LoginData) => {
+	if (data.access_token) {
+		setTokenInCookie('keycloak', data.access_token);
+		setAccessTokenExpiryInLocalStorage(data.expires_in);
+	}
+	if (data.refresh_token) {
+		setTokenInCookie('refreshToken', data.refresh_token);
+		setRefreshTokenExpiryInLocalStorage(data.refresh_expires_in);
+	}
+};
+
+const refreshTokens = (): Promise<void> => {
+	const currentTime = new Date().getTime();
+	const tokenExpiry = getTokenExpiryFromLocalStorage();
+
+	if (
+		tokenExpiry.refreshValidUntil <=
+		currentTime - RENEW_BEFORE_EXPIRY_TIME
+	) {
+		logout(true);
+		return Promise.resolve();
+	}
+
+	return refreshKeycloakAccessToken().then((response) => {
+		setTokens(response);
+	});
+};
+
+const startTimers = (
+	tokenValidMs: number,
+	tokenRefreshExpiredTimeout: number
+) => {
+	const tokenRefreshAccessTokenInterval =
+		tokenValidMs - RENEW_BEFORE_EXPIRY_TIME;
+
+	let refreshInterval;
+	if (tokenRefreshAccessTokenInterval > 0) {
+		refreshInterval = window.setInterval(() => {
+			refreshTokens();
+		}, tokenRefreshAccessTokenInterval);
+	}
+
+	if (tokenValidMs <= tokenRefreshExpiredTimeout) {
+		window.setTimeout(() => {
+			if (refreshInterval) {
+				window.clearInterval(refreshInterval);
+			}
+
+			logout(true);
+		}, tokenRefreshExpiredTimeout);
+	}
+};
+
+export const handleTokenRefresh = (): Promise<void> => {
+	return new Promise((resolve) => {
+		const currentTime = new Date().getTime();
+		const tokenExpiry = getTokenExpiryFromLocalStorage();
+		const tokenValidMs = tokenExpiry.validUntil - currentTime;
+
+		const tokenRefreshExpiredTimeout =
+			tokenExpiry.refreshValidUntil - currentTime;
+
+		if (tokenRefreshExpiredTimeout <= 0) {
+			logout(true);
+			resolve();
+		} else if (tokenValidMs <= 0) {
+			refreshTokens().then(() => {
+				startTimers(tokenValidMs, tokenRefreshExpiredTimeout);
+				resolve();
+			});
+		} else {
+			startTimers(tokenValidMs, tokenRefreshExpiredTimeout);
+			resolve();
+		}
+	});
+};

--- a/src/components/logout/logout.ts
+++ b/src/components/logout/logout.ts
@@ -2,6 +2,7 @@ import { config } from '../../resources/scripts/config';
 import { removeAllCookies } from '../sessionCookie/accessSessionCookie';
 import { rocketchatLogout } from '../apiWrapper';
 import { keycloakLogout } from '../apiWrapper';
+import { removeTokenExpiryFromLocalStorage } from '../sessionCookie/accessSessionLocalStorage';
 
 let isRequestInProgress = false;
 export const logout = (withRedirect: boolean = true, redirectUrl?: string) => {
@@ -29,6 +30,7 @@ const invalidateCookies = (
 	redirectUrl?: string
 ) => {
 	removeAllCookies();
+	removeTokenExpiryFromLocalStorage();
 	if (withRedirect) {
 		redirectAfterLogout(redirectUrl);
 	}

--- a/src/components/registration/autoLogin.ts
+++ b/src/components/registration/autoLogin.ts
@@ -4,6 +4,7 @@ import { setTokenInCookie } from '../sessionCookie/accessSessionCookie';
 import { config } from '../../resources/scripts/config';
 import { generateCsrfToken } from '../../resources/scripts/helpers/generateCsrfToken';
 import { encodeUsername } from '../../resources/scripts/helpers/encryptionHelpers';
+import { setTokens } from '../auth/auth';
 
 export interface LoginData {
 	data: {
@@ -11,7 +12,9 @@ export interface LoginData {
 		userId?: string;
 	};
 	access_token?: string;
+	expires_in?: number;
 	refresh_token?: string;
+	refresh_expires_in?: number;
 }
 
 export const autoLogin = (
@@ -27,12 +30,7 @@ export const autoLogin = (
 		encodeURIComponent(password)
 	)
 		.then((response) => {
-			if (response.access_token) {
-				setTokenInCookie('keycloak', response.access_token);
-			}
-			if (response.refresh_token) {
-				setTokenInCookie('refreshToken', response.refresh_token);
-			}
+			setTokens(response);
 
 			getRocketchatAccessToken(userHash, password)
 				.then((response) => {

--- a/src/components/sessionCookie/accessSessionLocalStorage.ts
+++ b/src/components/sessionCookie/accessSessionLocalStorage.ts
@@ -1,41 +1,33 @@
-export type LocalStorageKey = 'auth.valid_until' | 'auth.refresh_valid_until';
+export type LocalStorageKey =
+	| 'auth.access_token_valid_until'
+	| 'auth.refresh_token_valid_until';
 
 export const getLocalStorageItem = (key: LocalStorageKey): string => {
 	return localStorage.getItem(key);
-};
-
-export const setLocalStorageItem = (
-	key: LocalStorageKey,
-	value: string
-): void => {
-	localStorage.setItem(key, value);
 };
 
 export const removeLocalStorageItem = (key: LocalStorageKey): void => {
 	localStorage.removeItem(key);
 };
 
-export const setAccessTokenExpiryInLocalStorage = (expiresIn: number) => {
-	const validUntil = new Date().getTime() + expiresIn * 1000;
-	setLocalStorageItem('auth.valid_until', validUntil.toString());
-};
-
-export const setRefreshTokenExpiryInLocalStorage = (
-	refreshExpiresIn: number
+export const setTokenExpiryInLocalStorage = (
+	key: LocalStorageKey,
+	expiresInMs: number
 ) => {
-	const refreshValidUntil = new Date().getTime() + refreshExpiresIn * 1000;
-	setLocalStorageItem(
-		'auth.refresh_valid_until',
-		refreshValidUntil.toString()
-	);
+	const validUntilTime = new Date().getTime() + expiresInMs * 1000;
+	localStorage.setItem(key, validUntilTime.toString());
 };
 
 export const getTokenExpiryFromLocalStorage = () => ({
-	validUntil: parseInt(getLocalStorageItem('auth.valid_until')),
-	refreshValidUntil: parseInt(getLocalStorageItem('auth.refresh_valid_until'))
+	accessTokenValidUntilTime: parseInt(
+		getLocalStorageItem('auth.access_token_valid_until')
+	),
+	refreshTokenValidUntilTime: parseInt(
+		getLocalStorageItem('auth.refresh_token_valid_until')
+	)
 });
 
 export const removeTokenExpiryFromLocalStorage = () => {
-	removeLocalStorageItem('auth.valid_until');
-	removeLocalStorageItem('auth.refresh_valid_until');
+	removeLocalStorageItem('auth.access_token_valid_until');
+	removeLocalStorageItem('auth.refresh_token_valid_until');
 };

--- a/src/components/sessionCookie/accessSessionLocalStorage.ts
+++ b/src/components/sessionCookie/accessSessionLocalStorage.ts
@@ -1,0 +1,41 @@
+export type LocalStorageKey = 'auth.valid_until' | 'auth.refresh_valid_until';
+
+export const getLocalStorageItem = (key: LocalStorageKey): string => {
+	return localStorage.getItem(key);
+};
+
+export const setLocalStorageItem = (
+	key: LocalStorageKey,
+	value: string
+): void => {
+	localStorage.setItem(key, value);
+};
+
+export const removeLocalStorageItem = (key: LocalStorageKey): void => {
+	localStorage.removeItem(key);
+};
+
+export const setAccessTokenExpiryInLocalStorage = (expiresIn: number) => {
+	const validUntil = new Date().getTime() + expiresIn * 1000;
+	setLocalStorageItem('auth.valid_until', validUntil.toString());
+};
+
+export const setRefreshTokenExpiryInLocalStorage = (
+	refreshExpiresIn: number
+) => {
+	const refreshValidUntil = new Date().getTime() + refreshExpiresIn * 1000;
+	setLocalStorageItem(
+		'auth.refresh_valid_until',
+		refreshValidUntil.toString()
+	);
+};
+
+export const getTokenExpiryFromLocalStorage = () => ({
+	validUntil: parseInt(getLocalStorageItem('auth.valid_until')),
+	refreshValidUntil: parseInt(getLocalStorageItem('auth.refresh_valid_until'))
+});
+
+export const removeTokenExpiryFromLocalStorage = () => {
+	removeLocalStorageItem('auth.valid_until');
+	removeLocalStorageItem('auth.refresh_valid_until');
+};

--- a/src/components/sessionCookie/refreshKeycloakAccessToken.ts
+++ b/src/components/sessionCookie/refreshKeycloakAccessToken.ts
@@ -1,0 +1,35 @@
+import { config } from '../../resources/scripts/config';
+import { LoginData } from '../registration/autoLogin';
+import { getTokenFromCookie } from './accessSessionCookie';
+
+export const refreshKeycloakAccessToken = (): Promise<LoginData> =>
+	new Promise((resolve, reject) => {
+		const refreshToken = getTokenFromCookie('refreshToken');
+		const data =
+			'refresh_token=' +
+			refreshToken +
+			'&client_id=app&grant_type=refresh_token';
+		const url = config.endpoints.keycloakAccessToken;
+
+		const req = new Request(url, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded',
+				'cache-control': 'no-cache'
+			},
+			body: data
+		});
+
+		fetch(req)
+			.then((response) => {
+				if (response.status === 200) {
+					const data = response.json();
+					resolve(data);
+				} else if (response.status === 401) {
+					reject(new Error('keycloakLogin'));
+				}
+			})
+			.catch((error) => {
+				reject(new Error('keycloakLogin'));
+			});
+	});


### PR DESCRIPTION
## Proposed Changes

  - refresh keycloak access token 10s before it expires
  - logout if refresh token expires or we can't refresh access token in time
  - stay logged in as long as we can refresh the access token or the access token is still valid

## Testing

### Manually against BE

- Needs correct Keycloak configuration which is a bit tricky (from: https://stackoverflow.com/a/54679852)
    - http://caritas.local/auth/admin/master/console/#/realms/caritas-online-beratung/token-settings
    - SSO Session Idle: 999 days
    - SSO Session Max: 3 minutes
    - Client Session Idle: 0
    - Client Session Max: 0
    - Access Token Lifespan: 1 minute
- Log in to the app
  - Make sure that the first call to `token` in the devtools network tab responds with `expires_in: 60`, `refresh_expires_in: 180`
  - After 50, 100 and 150 seconds a new access token request should be visible in the devtools network tab
  - After 3 minutes a logout should happen

### Mocked with Cypress

Run `npm run dev` and click `tokens.spec.ts`

## Refactoring

- [x] Logging out because of expired refresh token should probably not happen as long as an access token is still valid
- [x] Only calculate time once before storing in local storage
- [x] first check in handletokenrefresh doesn't make sure access token is no longer valid?
- [x] `tokenValidMs` -> `accessTokenValidInMs`
- [x] `validUntil` -> `accessTokenValidUntilTime`
- [x] `refreshValidUntil` -> `refreshTokenValidUntilTime`