### PR TITLE
feat(tests): stomp mock

### DIFF
--- a/cypress/integration/login.spec.ts
+++ b/cypress/integration/login.spec.ts
@@ -2,6 +2,6 @@ describe('Login', () => {
 	it('should be able to login', () => {
 		cy.caritasMockedLogin();
 
-		cy.get('.app').should('exist');
+		cy.get('#appRoot').should('exist');
 	});
 });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,35 +1,107 @@
+import { WebSocket, Server } from 'mock-socket';
 import { config } from '../../src/resources/scripts/config';
+
+interface CaritasMockedLoginArgs {
+	auth?: {
+		expires_in?: number;
+		refresh_expires_in?: number;
+	};
+}
 
 declare global {
 	namespace Cypress {
 		interface Chainable {
-			caritasMockedLogin(): Chainable<Element>;
+			caritasMockedLogin(
+				args?: CaritasMockedLoginArgs
+			): Chainable<Element>;
 		}
 	}
 }
 
-Cypress.Commands.add('caritasMockedLogin', () => {
-	cy.intercept('POST', config.endpoints.keycloakAccessToken, {
-		fixture: 'auth.token.json'
-	});
-	cy.intercept('GET', config.endpoints.userData, {
-		fixture: 'service.users.data.json'
-	});
-	cy.intercept('GET', config.endpoints.userSessions, {
-		fixture: 'service.users.sessions.askers.json'
-	});
-	cy.intercept('GET', config.endpoints.liveservice, {
-		fixture: 'service.live.info.json'
-	});
-	cy.intercept('POST', config.endpoints.rocketchatAccessToken, {
-		fixture: 'api.v1.login.json'
-	});
-
-	cy.visit('/login.html');
-
-	cy.get('#username').type('username', { force: true });
-	cy.get('#passwordInput').type('password', {
-		force: true
-	});
-	cy.get('.button__primary').click();
+afterEach(() => {
+	// TODO: remove this temporary workarounds
+	// See:
+	// - https://github.com/cypress-io/cypress/issues/9170
+	// - https://github.com/cypress-io/cypress/issues/9362
+	// - https://github.com/cypress-io/cypress/issues/8926
+	cy.clearCookies();
+	cy.window().then((win) => (win.location.href = 'about:blank'));
 });
+
+Cypress.Commands.add(
+	'caritasMockedLogin',
+	(args: CaritasMockedLoginArgs = {}) => {
+		// stomp mock
+		let mockServer;
+		cy.on('window:before:load', (win) => {
+			const winWebSocket = win.WebSocket;
+			cy.stub(win, 'WebSocket').callsFake((url) => {
+				// TODO: "/service/live" should be synced with config, but the
+				// config hardcodes the http protocol in development
+				if (new URL(url).pathname.startsWith('/service/live')) {
+					if (mockServer) {
+						mockServer.stop();
+					}
+
+					let stompConnected = false;
+					mockServer = new Server(url);
+					mockServer.on('connection', (socket) => {
+						socket.on('message', () => {
+							if (!stompConnected) {
+								socket.send(
+									'a["CONNECTED\nversion:1.2\nheart-beat:600000,600000\n\n\u0000"]'
+								);
+								stompConnected = true;
+							}
+						});
+
+						socket.send('o');
+					});
+					return new WebSocket(url);
+				} else {
+					return new winWebSocket(url);
+				}
+			});
+		});
+
+		cy.fixture('auth.token').then((auth) =>
+			cy
+				.intercept('POST', config.endpoints.keycloakAccessToken, {
+					...auth,
+					...args.auth
+				})
+				.as('authToken')
+		);
+		cy.intercept('POST', config.endpoints.keycloakLogout, {}).as(
+			'authLogout'
+		);
+		cy.intercept('GET', config.endpoints.userData, {
+			fixture: 'service.users.data.json'
+		});
+		cy.intercept('GET', config.endpoints.userSessions, {
+			fixture: 'service.users.sessions.askers.json'
+		});
+		cy.intercept('GET', config.endpoints.liveservice, {
+			fixture: 'service.live.info.json'
+		});
+		cy.intercept('POST', config.endpoints.rocketchatAccessToken, {
+			fixture: 'api.v1.login.json'
+		});
+		cy.intercept('POST', config.endpoints.rocketchatLogout, {}).as(
+			'apiLogout'
+		);
+		cy.intercept('POST', config.endpoints.liveservice, {});
+		cy.intercept('GET', config.endpoints.liveservice, {});
+
+		cy.visit('login.html');
+
+		cy.get('#loginRoot');
+		cy.get('#username').type('username', { force: true });
+		cy.get('#passwordInput').type('password', {
+			force: true
+		});
+		cy.get('.button__primary').click();
+		cy.wait('@authToken');
+		cy.get('#appRoot');
+	}
+);

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,8 +1,9 @@
 {
 	"compilerOptions": {
-		"target": "es5",
-		"lib": ["es5", "dom"],
-		"types": ["cypress"]
+		"target": "es6",
+		"lib": ["es6", "dom"],
+		"types": ["cypress"],
+		"moduleResolution": "node"
 	},
 	"include": ["**/*.ts"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12290,6 +12290,15 @@
 				"minimist": "^1.2.5"
 			}
 		},
+		"mock-socket": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.0.3.tgz",
+			"integrity": "sha512-SxIiD2yE/By79p3cNAAXyLQWTvEFNEzcAO7PH+DzRqKSFaplAPFjiQLmw8ofmpCsZf+Rhfn2/xCJagpdGmYdTw==",
+			"dev": true,
+			"requires": {
+				"url-parse": "^1.4.4"
+			}
+		},
 		"modify-values": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
 		"cz-conventional-changelog": "3.3.0",
 		"husky": "4.3.0",
 		"lint-staged": "^10.5.1",
+		"mock-socket": "^9.0.3",
 		"node-sass": "4.14.1",
 		"npm-run-all": "^4.1.5",
 		"prettier": "2.1.2",


### PR DESCRIPTION
## Proposed Changes

  - Add stomp mock to mocked caritas login
  - Fix login test to check for `#appRoot` instead of `.app`
  - Empty mocks for live service endpoints
  - Temporary workarounds for cypress bugs
