### PR TITLE
refactor: upgrade cypress and remove workaround

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -22,16 +22,6 @@ declare global {
 	}
 }
 
-afterEach(() => {
-	// TODO: remove this temporary workarounds
-	// See:
-	// - https://github.com/cypress-io/cypress/issues/9170
-	// - https://github.com/cypress-io/cypress/issues/9362
-	// - https://github.com/cypress-io/cypress/issues/8926
-	// cy.window().then((win) => (win.location.href = 'about:blank'));
-	// cy.clearCookies();
-});
-
 Cypress.Commands.add(
 	'caritasMockedLogin',
 	(args: CaritasMockedLoginArgs = {}) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6307,9 +6307,9 @@
 			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
 		},
 		"cypress": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/cypress/-/cypress-6.0.0.tgz",
-			"integrity": "sha512-A/w9S15xGxX5UVeAQZacKBqaA0Uqlae9e5WMrehehAdFiLOZj08IgSVZOV8YqA9OH9Z0iBOnmsEkK3NNj43VrA==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/cypress/-/cypress-6.1.0.tgz",
+			"integrity": "sha512-uQnSxRcZ6hkf9R5cr8KpRBTzN88QZwLIImbf5DWa5RIxH6o5Gpff58EcjiYhAR8/8p9SGv7O6SRygq4H+k0Qpw==",
 			"dev": true,
 			"requires": {
 				"@cypress/listr-verbose-renderer": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
 		"breakpoint-sass": "2.7.1",
 		"concurrently": "^5.3.0",
 		"cross-env": "^7.0.2",
-		"cypress": "^6.0.0",
+		"cypress": "^6.1.0",
 		"cypress-file-upload": "^4.1.1",
 		"cz-conventional-changelog": "3.3.0",
 		"husky": "4.3.0",


### PR DESCRIPTION
## Proposed Changes

  - Cypress 6.1.0 fixes the bug which made the workaround necessary, so we can remove that now

