### PR TITLE
feat: generate types from openapi service yaml urls

### DIFF
--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -5,5 +5,5 @@
 		"types": ["cypress"],
 		"moduleResolution": "node"
 	},
-	"include": ["**/*.ts"]
+	"include": ["**/*.ts", "../src/generated/**/*.ts"]
 }

--- a/dtsgen.ts
+++ b/dtsgen.ts
@@ -1,0 +1,80 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import dtsgenerator, { readSchemaFromUrl } from 'dtsgenerator';
+import prettier from 'prettier';
+
+const rawOrgUrl = 'https://raw.githubusercontent.com/CaritasDeutschland';
+const services = [
+	{
+		path: 'caritas-onlineBeratung-userService/develop/api/userservice.yaml',
+		namespace: 'UserService',
+		out: 'userservice.d.ts'
+	},
+	{
+		path:
+			'caritas-onlineBeratung-agencyService/develop/api/agencyservice.yaml',
+		namespace: 'AgencyService',
+		out: 'agencyservice.d.ts'
+	},
+	{
+		path:
+			'caritas-onlineBeratung-uploadService/develop/api/uploadservice.yaml',
+		namespace: 'UploadService',
+		out: 'uploadservice.d.ts'
+	},
+	{
+		path:
+			'caritas-onlineBeratung-messageService/develop/api/messageservice.yaml',
+		namespace: 'MessageService',
+		out: 'messageservice.d.ts'
+	},
+	{
+		path: 'caritas-onlineBeratung-mailService/develop/api/mailservice.yaml',
+		namespace: 'MailService',
+		out: 'mailservice.d.ts'
+	},
+	{
+		path: 'caritas-onlineBeratung-liveService/develop/api/liveservice.yaml',
+		namespace: 'LiveService',
+		out: 'liveservice.d.ts'
+	}
+];
+
+(async () => {
+	try {
+		const prettierConfigFile = await prettier.resolveConfigFile();
+		const prettierConfig = await prettier.resolveConfig(prettierConfigFile);
+
+		for (const service of services) {
+			const schema = await readSchemaFromUrl(
+				`${rawOrgUrl}/${service.path}`
+			);
+			const content = await dtsgenerator({
+				contents: [schema],
+				config: {
+					plugins: {
+						'@dtsgenerator/replace-namespace': {
+							map: [
+								{
+									from: ['Components', 'Schema'],
+									to: [service.namespace]
+								}
+							]
+						}
+					}
+				}
+			});
+
+			await fs.writeFile(
+				path.join('src', 'generated', service.out),
+				prettier.format(content, {
+					parser: 'typescript',
+					...prettierConfig
+				})
+			);
+		}
+	} catch (err) {
+		console.error(`Something went wrong: ${err}`);
+		process.exit(1);
+	}
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1782,6 +1782,24 @@
 				}
 			}
 		},
+		"@dtsgenerator/replace-namespace": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@dtsgenerator/replace-namespace/-/replace-namespace-1.4.1.tgz",
+			"integrity": "sha512-L0DFdirXdb6CBYiV5ILYfcgqY83ThhhYBhauhn3MserpTPs+ODLLMGCRPyWPAxH9z7YUCho3y37si7EVGfJYJQ==",
+			"dev": true,
+			"requires": {
+				"dtsgenerator": "^3.5.0",
+				"tslib": "^2.0.3"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+					"dev": true
+				}
+			}
+		},
 		"@emotion/cache": {
 			"version": "10.0.29",
 			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
@@ -2278,6 +2296,12 @@
 			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
 			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
 		},
+		"@types/prettier": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.5.tgz",
+			"integrity": "sha512-UEyp8LwZ4Dg30kVU2Q3amHHyTn1jEdhCIE59ANed76GaT1Vp76DD3ZWSAxgCrw6wJ0TqeoBpqmfUHiUDPs//HQ==",
+			"dev": true
+		},
 		"@types/prop-types": {
 			"version": "15.7.3",
 			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
@@ -2694,6 +2718,15 @@
 			"requires": {
 				"loader-utils": "^2.0.0",
 				"regex-parser": "^2.2.11"
+			}
+		},
+		"agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"dev": true,
+			"requires": {
+				"debug": "4"
 			}
 		},
 		"aggregate-error": {
@@ -5967,6 +6000,12 @@
 				"warning": "^4.0.3"
 			}
 		},
+		"create-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+			"dev": true
+		},
 		"cross-env": {
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
@@ -6818,6 +6857,12 @@
 				}
 			}
 		},
+		"diff": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+			"dev": true
+		},
 		"diffie-hellman": {
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
@@ -7060,6 +7105,52 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/draft-js-utils/-/draft-js-utils-1.4.0.tgz",
 			"integrity": "sha512-8s9FFuKC+lOWGwJ0b3om2PF+uXrqQPaEQlPJI7UxdzxTYGMeKouMPA9+YlPn52zcAVElIZtd2tXj6eQmvlKelw=="
+		},
+		"dtsgenerator": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/dtsgenerator/-/dtsgenerator-3.5.0.tgz",
+			"integrity": "sha512-AlcCpjFm4e3dgrdgcEq1jsA/ew2xkg0WlRf9Sl/23WvC7qltMJtdEWRrgwcTp3yFPE+wXVzP1h756pY+gkfVKA==",
+			"dev": true,
+			"requires": {
+				"commander": "^6.2.1",
+				"cross-fetch": "^3.0.6",
+				"debug": "^4.3.1",
+				"glob": "^7.1.6",
+				"https-proxy-agent": "^5.0.0",
+				"js-yaml": "^3.14.1",
+				"tslib": "^2.0.3",
+				"typescript": "~4.1.3"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+					"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+					"dev": true
+				},
+				"js-yaml": {
+					"version": "3.14.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+					"dev": true,
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
+				},
+				"tslib": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+					"integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+					"dev": true
+				},
+				"typescript": {
+					"version": "4.1.3",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+					"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+					"dev": true
+				}
+			}
 		},
 		"duplexer": {
 			"version": "0.1.2",
@@ -9939,6 +10030,16 @@
 			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
 			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
 		},
+		"https-proxy-agent": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+			"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+			"dev": true,
+			"requires": {
+				"agent-base": "6",
+				"debug": "4"
+			}
+		},
 		"human-signals": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
@@ -11775,6 +11876,12 @@
 					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 				}
 			}
+		},
+		"make-error": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+			"dev": true
 		},
 		"make-plural": {
 			"version": "4.3.0",
@@ -18489,6 +18596,28 @@
 			"resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
 			"integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
 		},
+		"ts-node": {
+			"version": "9.1.1",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+			"integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+			"dev": true,
+			"requires": {
+				"arg": "^4.1.0",
+				"create-require": "^1.1.0",
+				"diff": "^4.0.1",
+				"make-error": "^1.1.1",
+				"source-map-support": "^0.5.17",
+				"yn": "3.1.1"
+			},
+			"dependencies": {
+				"arg": {
+					"version": "4.1.3",
+					"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+					"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+					"dev": true
+				}
+			}
+		},
 		"ts-pnp": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",
@@ -20369,6 +20498,12 @@
 				"buffer-crc32": "~0.2.3",
 				"fd-slicer": "~1.1.0"
 			}
+		},
+		"yn": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+			"dev": true
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -93,12 +93,15 @@
 	"devDependencies": {
 		"@commitlint/cli": "11.0.0",
 		"@commitlint/config-conventional": "11.0.0",
+		"@dtsgenerator/replace-namespace": "^1.4.1",
+		"@types/prettier": "^2.1.5",
 		"breakpoint-sass": "2.7.1",
 		"concurrently": "^5.3.0",
 		"cross-env": "^7.0.2",
 		"cypress": "^6.1.0",
 		"cypress-file-upload": "^4.1.1",
 		"cz-conventional-changelog": "3.3.0",
+		"dtsgenerator": "^3.5.0",
 		"husky": "4.3.0",
 		"lint-staged": "^10.5.1",
 		"mock-socket": "^9.0.3",
@@ -108,6 +111,7 @@
 		"prettier-eslint-cli": "5.0.0",
 		"serve": "^11.3.2",
 		"standard-version": "9.0.0",
+		"ts-node": "^9.1.1",
 		"uuid": "^8.3.2",
 		"wait-on": "^5.2.0"
 	},
@@ -122,7 +126,8 @@
 		"dev:cy:start-cra": "BROWSER=none npm start",
 		"dev:cy:wait-and-open": "run-s dev:cy:wait-and-open:*",
 		"dev:cy:wait-and-open:wait-on-cra": "wait-on http://caritas.local:9000",
-		"dev:cy:wait-and-open:open": "cross-env NODE_ENV=development cypress open"
+		"dev:cy:wait-and-open:open": "cross-env NODE_ENV=development cypress open",
+		"dtsgen": "ts-node dtsgen.ts"
 	},
 	"eslintConfig": {
 		"extends": [

--- a/src/generated/agencyservice.d.ts
+++ b/src/generated/agencyservice.d.ts
@@ -1,0 +1,93 @@
+declare namespace AgencyService {
+	namespace Schemas {
+		export interface AgencyResponseDTO {
+			/**
+			 * example:
+			 * 684
+			 */
+			id?: number; // int64
+			/**
+			 * example:
+			 * Suchtberatung Freiburg
+			 */
+			name?: string;
+			/**
+			 * example:
+			 * 79106
+			 */
+			postcode?: string;
+			/**
+			 * example:
+			 * Bonn
+			 */
+			city?: string;
+			/**
+			 * example:
+			 * Our agency provides help for the following topics: Lorem ipsum..
+			 */
+			description?: string;
+			/**
+			 * example:
+			 * false
+			 */
+			teamAgency?: boolean;
+			/**
+			 * example:
+			 * false
+			 */
+			offline?: boolean;
+			/**
+			 * example:
+			 * 0
+			 */
+			consultingType?: number;
+		}
+	}
+}
+declare namespace Paths {
+	namespace GetAgencies {
+		namespace Parameters {
+			/**
+			 * example:
+			 * 5
+			 */
+			export type ConsultingType = number; // int32
+			/**
+			 * example:
+			 * 56789
+			 */
+			export type Postcode = string;
+		}
+		export interface QueryParameters {
+			postcode: /**
+			 * example:
+			 * 56789
+			 */
+			Parameters.Postcode;
+			consultingType: /**
+			 * example:
+			 * 5
+			 */
+			Parameters.ConsultingType /* int32 */;
+		}
+		namespace Responses {
+			export type $200 = AgencyService.Schemas.AgencyResponseDTO[];
+			export interface $400 {}
+			export interface $500 {}
+		}
+	}
+	namespace GetAgenciesByIds {
+		namespace Parameters {
+			export type AgencyIds = number /* int64 */[];
+		}
+		export interface PathParameters {
+			agencyIds: Parameters.AgencyIds;
+		}
+		namespace Responses {
+			export type $200 = AgencyService.Schemas.AgencyResponseDTO[];
+			export interface $400 {}
+			export interface $401 {}
+			export interface $500 {}
+		}
+	}
+}

--- a/src/generated/liveservice.d.ts
+++ b/src/generated/liveservice.d.ts
@@ -1,0 +1,21 @@
+declare namespace LiveService {
+	namespace Schemas {
+		export type EventType = 'directMessage';
+	}
+}
+declare namespace Paths {
+	namespace SendLiveEvent {
+		namespace Parameters {
+			export type UserIds = string[];
+		}
+		export interface QueryParameters {
+			userIds: Parameters.UserIds;
+		}
+		export type RequestBody = LiveService.Schemas.EventType;
+		namespace Responses {
+			export interface $200 {}
+			export interface $400 {}
+			export interface $500 {}
+		}
+	}
+}

--- a/src/generated/mailservice.d.ts
+++ b/src/generated/mailservice.d.ts
@@ -1,0 +1,38 @@
+declare namespace MailService {
+	namespace Schemas {
+		export interface MailDTO {
+			/**
+			 * example:
+			 * template
+			 */
+			template: string;
+			/**
+			 * example:
+			 * max@mustermann.de
+			 */
+			email: string;
+			templateData?: TemplateDataDTO[];
+		}
+		export interface MailsDTO {
+			mails: MailDTO[];
+		}
+		export interface TemplateDataDTO {
+			/**
+			 * example:
+			 * name
+			 */
+			key: string;
+			value: string;
+		}
+	}
+}
+declare namespace Paths {
+	namespace SendMails {
+		export type RequestBody = MailService.Schemas.MailsDTO;
+		namespace Responses {
+			export interface $200 {}
+			export interface $400 {}
+			export interface $500 {}
+		}
+	}
+}

--- a/src/generated/messageservice.d.ts
+++ b/src/generated/messageservice.d.ts
@@ -1,0 +1,322 @@
+declare namespace MessageService {
+	namespace Schemas {
+		export interface AttachmentDTO {
+			/**
+			 * example:
+			 * filename.png
+			 */
+			'title': string;
+			/**
+			 * example:
+			 * file
+			 */
+			'type': string;
+			/**
+			 * example:
+			 * Description
+			 */
+			'description': string;
+			/**
+			 * example:
+			 * /file-upload/ijxact7nd5SMpSwiS/file.png
+			 */
+			'title_link': string;
+			/**
+			 * example:
+			 * true
+			 */
+			'title_link_download': boolean;
+			/**
+			 * example:
+			 * /file-upload/ijxact7nd5SMpSwiS/file.png
+			 */
+			'image_url': string;
+			/**
+			 * example:
+			 * image/png
+			 */
+			'image_type': string;
+			/**
+			 * example:
+			 * 36461
+			 */
+			'image_size': number;
+			/**
+			 * example:
+			 * /9j/2wBDAAYEBQYFBAYGBQY
+			 */
+			'image-preview'?: string;
+		}
+		export interface FileDTO {
+			/**
+			 * example:
+			 * M73fE4WhYF4peYB3s
+			 */
+			_id: string;
+			/**
+			 * example:
+			 * filename.jpg
+			 */
+			name: string;
+			/**
+			 * example:
+			 * image/jepg
+			 */
+			type: string;
+		}
+		export interface ForwardMessageDTO {
+			/**
+			 * example:
+			 * Lorem ipsum dolor sit amet, consetetur...
+			 */
+			message: string;
+			/**
+			 * Full qualified timestamp
+			 * example:
+			 * 2018-11-15T09:33:00.057Z
+			 */
+			timestamp: string;
+			/**
+			 * example:
+			 * asker23
+			 */
+			username: string;
+			/**
+			 * example:
+			 * ag89h3tjkerg94t
+			 */
+			rcUserId: string;
+		}
+		export interface MasterKeyDTO {
+			/**
+			 * example:
+			 * sdj8wnFNASj324!ksldf9
+			 */
+			masterKey: string;
+		}
+		export interface MessageDTO {
+			/**
+			 * example:
+			 * Lorem ipsum dolor sit amet, consetetur...
+			 */
+			message: string;
+			/**
+			 * example:
+			 * true
+			 */
+			sendNotification?: boolean;
+		}
+		export interface MessageStreamDTO {
+			messages: MessagesDTO[];
+			/**
+			 * example:
+			 * 2
+			 */
+			count: string;
+			/**
+			 * example:
+			 * 0
+			 */
+			offset: string;
+			/**
+			 * example:
+			 * 2
+			 */
+			total: string;
+			/**
+			 * example:
+			 * true
+			 */
+			success: string;
+			/**
+			 * example:
+			 * true
+			 */
+			cleaned: string;
+		}
+		export interface MessagesDTO {
+			/**
+			 * example:
+			 * M73fE4WhYF4peYB3s
+			 */
+			_id: string;
+			alias?: ForwardMessageDTO;
+			/**
+			 * example:
+			 * fR2Rz7dmWmHdXE8uz
+			 */
+			rid: string;
+			/**
+			 * example:
+			 * Lorem ipsum dolor sit amet, consetetur...
+			 */
+			msg: string;
+			/**
+			 * Full qualified timestamp
+			 * example:
+			 * 2018-11-15T09:33:00.057Z
+			 */
+			ts: string;
+			u: UserDTO;
+			unread: boolean;
+			mentions: string[];
+			channels: string[];
+			/**
+			 * Full qualified timestamp
+			 * example:
+			 * 2018-11-15T09:33:00.057Z
+			 */
+			_updatedAt: string;
+			attachments?: AttachmentDTO[];
+			file?: FileDTO;
+		}
+		export interface UserDTO {
+			/**
+			 * example:
+			 * vppRFqjrzTsTZ6iEn
+			 */
+			_id: string;
+			/**
+			 * example:
+			 * test
+			 */
+			username: string;
+			/**
+			 * example:
+			 * Mustermax
+			 */
+			name: string;
+		}
+	}
+}
+declare namespace Paths {
+	namespace CreateFeedbackMessage {
+		export interface HeaderParameters {
+			RCToken: Parameters.RCToken;
+			RCUserId: Parameters.RCUserId;
+			RCFeedbackGroupId: Parameters.RCFeedbackGroupId;
+		}
+		namespace Parameters {
+			export type RCFeedbackGroupId = string;
+			export type RCToken = string;
+			export type RCUserId = string;
+		}
+		export type RequestBody = MessageService.Schemas.MessageDTO;
+		namespace Responses {
+			export interface $201 {}
+			export interface $400 {}
+			export interface $401 {}
+			export interface $403 {}
+			export interface $500 {}
+		}
+	}
+	namespace CreateMessage {
+		export interface HeaderParameters {
+			RCToken: Parameters.RCToken;
+			RCUserId: Parameters.RCUserId;
+			RCGroupId: Parameters.RCGroupId;
+		}
+		namespace Parameters {
+			export type RCGroupId = string;
+			export type RCToken = string;
+			export type RCUserId = string;
+		}
+		export type RequestBody = MessageService.Schemas.MessageDTO;
+		namespace Responses {
+			export interface $201 {}
+			export interface $400 {}
+			export interface $401 {}
+			export interface $403 {}
+			export interface $500 {}
+		}
+	}
+	namespace FindDraftMessage {
+		export interface HeaderParameters {
+			RCGroupId: Parameters.RCGroupId;
+		}
+		namespace Parameters {
+			export type RCGroupId = string;
+		}
+		namespace Responses {
+			export type $200 = string;
+			export interface $204 {}
+			export interface $400 {}
+			export interface $401 {}
+			export interface $403 {}
+			export interface $500 {}
+		}
+	}
+	namespace ForwardMessage {
+		export interface HeaderParameters {
+			RCToken: Parameters.RCToken;
+			RCUserId: Parameters.RCUserId;
+			RCGroupId: Parameters.RCGroupId;
+		}
+		namespace Parameters {
+			export type RCGroupId = string;
+			export type RCToken = string;
+			export type RCUserId = string;
+		}
+		export type RequestBody = MessageService.Schemas.ForwardMessageDTO;
+		namespace Responses {
+			export interface $201 {}
+			export interface $400 {}
+			export interface $401 {}
+			export interface $403 {}
+			export interface $500 {}
+		}
+	}
+	namespace GetMessageStream {
+		export interface HeaderParameters {
+			RCToken: Parameters.RCToken;
+			RCUserId: Parameters.RCUserId;
+		}
+		namespace Parameters {
+			export type Count = number;
+			export type Offset = number;
+			export type RCToken = string;
+			export type RCUserId = string;
+			export type RcGroupId = string;
+		}
+		export interface QueryParameters {
+			rcGroupId: Parameters.RcGroupId;
+			offset: Parameters.Offset;
+			count: Parameters.Count;
+		}
+		namespace Responses {
+			export type $200 = MessageService.Schemas.MessageStreamDTO;
+			export interface $204 {}
+			export interface $400 {}
+			export interface $401 {}
+			export interface $403 {}
+			export interface $500 {}
+		}
+	}
+	namespace SaveDraftMessage {
+		export interface HeaderParameters {
+			RCGroupId: Parameters.RCGroupId;
+		}
+		namespace Parameters {
+			export type RCGroupId = string;
+		}
+		export type RequestBody = string;
+		namespace Responses {
+			export interface $200 {}
+			export interface $201 {}
+			export interface $400 {}
+			export interface $401 {}
+			export interface $403 {}
+			export interface $500 {}
+		}
+	}
+	namespace UpdateKey {
+		export type RequestBody = MessageService.Schemas.MasterKeyDTO;
+		namespace Responses {
+			export interface $202 {}
+			export interface $401 {}
+			export interface $403 {}
+			export interface $409 {}
+			export interface $500 {}
+		}
+	}
+}

--- a/src/generated/uploadservice.d.ts
+++ b/src/generated/uploadservice.d.ts
@@ -1,0 +1,113 @@
+declare namespace UploadService {
+	namespace Schemas {
+		export interface MasterKeyDto {
+			/**
+			 * example:
+			 * sdj8wnFNASj324!ksldf9
+			 */
+			masterKey: string;
+		}
+	}
+}
+declare namespace Paths {
+	namespace UpdateKey {
+		export type RequestBody = UploadService.Schemas.MasterKeyDto;
+		namespace Responses {
+			export interface $202 {}
+			export interface $401 {}
+			export interface $403 {}
+			export interface $409 {}
+			export interface $500 {}
+		}
+	}
+	namespace UploadFileToFeedbackRoom {
+		export interface HeaderParameters {
+			RCToken: Parameters.RCToken;
+			RCUserId: Parameters.RCUserId;
+		}
+		namespace Parameters {
+			export type FeedbackRoomId = string;
+			export type RCToken = string;
+			export type RCUserId = string;
+		}
+		export interface PathParameters {
+			feedbackRoomId: Parameters.FeedbackRoomId;
+		}
+		export interface RequestBody {
+			/**
+			 * A text message
+			 */
+			msg?: string;
+			/**
+			 * A description of the file
+			 */
+			description?: string;
+			/**
+			 * The thread message id (if you want upload a file to a thread)
+			 */
+			tmId?: string;
+			/**
+			 * File to upload
+			 */
+			file: string; // binary
+			/**
+			 * Flag, whether an email notification should be sent or not (true/false)
+			 */
+			sendNotification: string;
+		}
+		namespace Responses {
+			export interface $201 {}
+			export interface $400 {}
+			export interface $401 {}
+			export interface $403 {}
+			export interface $413 {}
+			export interface $415 {}
+			export interface $500 {}
+		}
+	}
+	namespace UploadFileToRoom {
+		export interface HeaderParameters {
+			RCToken: Parameters.RCToken;
+			RCUserId: Parameters.RCUserId;
+		}
+		namespace Parameters {
+			export type RCToken = string;
+			export type RCUserId = string;
+			export type RoomId = string;
+		}
+		export interface PathParameters {
+			roomId: Parameters.RoomId;
+		}
+		export interface RequestBody {
+			/**
+			 * A text message
+			 */
+			msg?: string;
+			/**
+			 * A description of the file
+			 */
+			description?: string;
+			/**
+			 * The thread message id (if you want upload a file to a thread)
+			 */
+			tmId?: string;
+			/**
+			 * File to upload
+			 */
+			file: string; // binary
+			/**
+			 * Flag, whether an email notification should be sent or not (true/false)
+			 */
+			sendNotification: string;
+		}
+		namespace Responses {
+			export interface $201 {}
+			export interface $400 {}
+			export interface $401 {}
+			export interface $403 {}
+			export interface $413 {}
+			export interface $415 {}
+			export interface $500 {}
+		}
+	}
+}

--- a/src/generated/userservice.d.ts
+++ b/src/generated/userservice.d.ts
@@ -1,0 +1,1006 @@
+declare namespace UserService {
+	namespace Schemas {
+		export interface AbsenceDTO {
+			/**
+			 * example:
+			 * true
+			 */
+			absent: boolean;
+			/**
+			 * example:
+			 * Ich bin abwesend vom...bis.
+			 */
+			message?: string;
+		}
+		export interface AgencyDTO {
+			/**
+			 * example:
+			 * 153918
+			 */
+			id?: number; // int64
+			/**
+			 * example:
+			 * Alkohol-Beratung
+			 */
+			name?: string;
+			/**
+			 * example:
+			 * 53113
+			 */
+			postcode?: string;
+			/**
+			 * example:
+			 * Bonn
+			 */
+			city?: string;
+			/**
+			 * example:
+			 * Our agency provides help for the following topics..
+			 */
+			description?: string;
+			/**
+			 * example:
+			 * false
+			 */
+			teamAgency?: boolean;
+			/**
+			 * example:
+			 * false
+			 */
+			offline?: boolean;
+			consultingType?: ConsultingType;
+		}
+		export interface ChatDTO {
+			/**
+			 * example:
+			 * Wöchentliche Drogenberatung
+			 */
+			topic: string;
+			/**
+			 * example:
+			 * 2019-10-23T00:00:00.000Z
+			 */
+			startDate: string; // date
+			/**
+			 * example:
+			 * 725
+			 */
+			startTime: string; // time
+			/**
+			 * example:
+			 * 120
+			 */
+			duration: number;
+			/**
+			 * example:
+			 * false
+			 */
+			repetitive: boolean;
+		}
+		export interface ChatInfoResponseDTO {
+			/**
+			 * example:
+			 * 153918
+			 */
+			id: number; // int64
+			/**
+			 * example:
+			 * xGklslk2JJKK
+			 */
+			groupId: string;
+			/**
+			 * example:
+			 * false
+			 */
+			active: boolean;
+		}
+		export interface ChatMemberResponseDTO {
+			_id?: string;
+			status?: string;
+			username?: string;
+			name?: string;
+			utcOffset?: string;
+		}
+		export interface ChatMembersResponseDTO {
+			members?: ChatMemberResponseDTO[];
+		}
+		export interface ConsultantResponseDTO {
+			/**
+			 * example:
+			 * aadc0ecf-c048-4bfc-857d-8c9b2e425500
+			 */
+			consultantId?: string;
+			/**
+			 * example:
+			 * Max
+			 */
+			firstName?: string;
+			/**
+			 * example:
+			 * Mustermann
+			 */
+			lastName?: string;
+		}
+		export interface ConsultantSessionListResponseDTO {
+			sessions: ConsultantSessionResponseDTO[];
+			/**
+			 * Session value where to start from in the query (0 = first item)
+			 */
+			offset: number;
+			/**
+			 * Number of sessions which are being returned
+			 */
+			count: number;
+			/**
+			 * Total amount of sessions the consultant has
+			 */
+			total: number;
+		}
+		export interface ConsultantSessionResponseDTO {
+			session?: SessionDTO;
+			chat?: UserChatDTO;
+			user?: SessionUserDTO;
+			consultant?: SessionConsultantForConsultantDTO;
+			latestMessage?: Date;
+		}
+		export interface ConsultingType {}
+		export interface ConsultingTypeMap {
+			value?: unknown;
+		}
+		export interface CreateChatResponseDTO {
+			/**
+			 * example:
+			 * WCET6GWir78pNMyyD
+			 */
+			groupId: string;
+			/**
+			 * example:
+			 * http://{baseUrl}}/{consultingTypeName}/GEYDA
+			 */
+			chatLink: string;
+		}
+		export interface CreateUserResponseDTO {
+			/**
+			 * example:
+			 * 0
+			 */
+			usernameAvailable: number;
+			/**
+			 * example:
+			 * 1
+			 */
+			emailAvailable: number;
+		}
+		export interface Date {}
+		export interface EnquiryMessageDTO {
+			/**
+			 * example:
+			 * Lorem ipsum dolor sit amet, consetetur...
+			 */
+			message: string;
+		}
+		export interface HttpStatus {}
+		export interface MasterKeyDTO {
+			/**
+			 * example:
+			 * sdj8wnFNASj324!ksldf9
+			 */
+			masterKey: string;
+		}
+		export interface MonitoringDTO {
+			additionalProperties?: Properties;
+		}
+		export interface NewMessageNotificationDTO {
+			/**
+			 * example:
+			 * fR2Rz7dmWmHdXE8uz
+			 */
+			rcGroupId: string;
+		}
+		export interface NewRegistrationDto {
+			/**
+			 * example:
+			 * 79098
+			 */
+			postcode: string;
+			/**
+			 * example:
+			 * 232
+			 */
+			agencyId: number; // int64
+			/**
+			 * example:
+			 * 1
+			 */
+			consultingType: string;
+		}
+		export interface NewRegistrationResponseDto {
+			sessionId?: number; // int64
+			status?: HttpStatus;
+		}
+		export interface PasswordDTO {
+			/**
+			 * example:
+			 * oldpass@w0rd
+			 */
+			oldPassword: string;
+			/**
+			 * example:
+			 * newpass@w0rd
+			 */
+			newPassword: string;
+		}
+		export interface Properties {
+			value?: unknown;
+		}
+		export interface SessionAttachmentDTO {
+			/**
+			 * example:
+			 * image/png
+			 */
+			fileType?: string;
+			/**
+			 * example:
+			 * /9j/2wBDAAYEBQYFBAYGBQY
+			 */
+			imagePreview?: string;
+			/**
+			 * example:
+			 * true
+			 */
+			fileReceived?: boolean;
+		}
+		export interface SessionConsultantForConsultantDTO {
+			/**
+			 * example:
+			 * 153918
+			 */
+			id?: string;
+			/**
+			 * example:
+			 * Max
+			 */
+			firstName?: string;
+			/**
+			 * example:
+			 * Mustermann
+			 */
+			lastName?: string;
+		}
+		export interface SessionConsultantForUserDTO {
+			/**
+			 * example:
+			 * beraterXYZ
+			 */
+			username?: string;
+			/**
+			 * example:
+			 * true
+			 */
+			isAbsent?: boolean;
+			/**
+			 * example:
+			 * Bin nicht da
+			 */
+			absenceMessage?: string;
+		}
+		export interface SessionDTO {
+			/**
+			 * example:
+			 * 153918
+			 */
+			id: number; // int64
+			/**
+			 * example:
+			 * 100
+			 */
+			agencyId: number; // int64
+			/**
+			 * example:
+			 * 1
+			 */
+			consultingType: number;
+			/**
+			 * example:
+			 * 0
+			 */
+			status: number;
+			/**
+			 * example:
+			 * 79098
+			 */
+			postcode?: string;
+			/**
+			 * Rocket.Chat room ID
+			 * example:
+			 * xGklslk2JJKK
+			 */
+			groupId?: string;
+			/**
+			 * Rocket.Chat feedback room ID
+			 * example:
+			 * 8ertjlasdKJA
+			 */
+			feedbackGroupId?: string;
+			/**
+			 * asker Rocket.Chat ID
+			 * example:
+			 * 8ertjlasdKJA
+			 */
+			askerRcId?: string;
+			/**
+			 * example:
+			 * Thanks for the answer
+			 */
+			lastMessage?: string;
+			/**
+			 * example:
+			 * 1539184948
+			 */
+			messageDate?: number; // int64
+			/**
+			 * example:
+			 * false
+			 */
+			messagesRead?: boolean;
+			/**
+			 * example:
+			 * true
+			 */
+			feedbackRead?: boolean;
+			/**
+			 * example:
+			 * false
+			 */
+			isTeamSession?: boolean;
+			/**
+			 * example:
+			 * true
+			 */
+			monitoring?: boolean;
+			attachment?: SessionAttachmentDTO;
+		}
+		export interface SessionUserDTO {
+			/**
+			 * example:
+			 * max94
+			 */
+			username?: string;
+			/**
+			 * LinkedHashMap<String, Object>
+			 */
+			sessionData?: string;
+		}
+		export interface UpdateChatResponseDTO {
+			/**
+			 * example:
+			 * WCET6GWir78pNMyyD
+			 */
+			groupId: string;
+			/**
+			 * example:
+			 * http://{baseUrl}}/{consultingTypeName}/GEYDA
+			 */
+			chatLink: string;
+		}
+		export interface UserChatDTO {
+			/**
+			 * example:
+			 * 153918
+			 */
+			id: number; // int64
+			/**
+			 * example:
+			 * Drugs
+			 */
+			topic: string;
+			/**
+			 * example:
+			 * 2019-10-23T00:00:00.000Z
+			 */
+			startDate: string; // date
+			/**
+			 * example:
+			 * 725
+			 */
+			startTime: string; // time
+			/**
+			 * example:
+			 * 120
+			 */
+			duration: number;
+			/**
+			 * example:
+			 * false
+			 */
+			repetitive: boolean;
+			/**
+			 * example:
+			 * false
+			 */
+			active: boolean;
+			/**
+			 * example:
+			 * 0
+			 */
+			consultingType: number;
+			/**
+			 * example:
+			 * Thanks for the answer
+			 */
+			lastMessage?: string;
+			/**
+			 * example:
+			 * 1539184948
+			 */
+			messageDate?: number; // int64
+			/**
+			 * example:
+			 * false
+			 */
+			messagesRead?: boolean;
+			/**
+			 * example:
+			 * xGklslk2JJKK
+			 */
+			groupId: string;
+			attachment?: SessionAttachmentDTO;
+			/**
+			 * example:
+			 * false
+			 */
+			subscribed?: boolean;
+			moderators?: string[];
+			startDateWithTime?: string; // date-time
+		}
+		export interface UserDTO {
+			/**
+			 * example:
+			 * max94
+			 */
+			username: string;
+			/**
+			 * example:
+			 * 79098
+			 */
+			postcode: string;
+			/**
+			 * example:
+			 * 15
+			 */
+			agencyId: number; // int64
+			/**
+			 * example:
+			 * pass@w0rd
+			 */
+			password: string; // password
+			/**
+			 * example:
+			 * max@mustermann.de
+			 */
+			email?: string; // email
+			/**
+			 * comma separated list of addictive drug IDs
+			 * example:
+			 * 2,4
+			 */
+			addictiveDrugs?: string;
+			/**
+			 * example:
+			 * 2
+			 */
+			relation?: string;
+			/**
+			 * example:
+			 * 17
+			 */
+			age?: string;
+			/**
+			 * example:
+			 * 0
+			 */
+			gender?: string;
+			/**
+			 * example:
+			 * 8
+			 */
+			state?: string;
+			/**
+			 * example:
+			 * true
+			 */
+			termsAccepted: string;
+			/**
+			 * example:
+			 * 3
+			 */
+			consultingType: string;
+		}
+		export interface UserDataResponseDTO {
+			/**
+			 * example:
+			 * ajsd89-sdf9-sadk-as8j-asdf8jo
+			 */
+			userId?: string;
+			/**
+			 * example:
+			 * max.muster
+			 */
+			userName?: string;
+			/**
+			 * example:
+			 * Max
+			 */
+			firstName?: string;
+			/**
+			 * example:
+			 * Mustermann
+			 */
+			lastName?: string;
+			/**
+			 * example:
+			 * maxmuster@mann.com
+			 */
+			email?: string; // email
+			/**
+			 * example:
+			 * false
+			 */
+			isAbsent?: boolean;
+			/**
+			 * example:
+			 * true
+			 */
+			isFormalLanguage?: boolean;
+			/**
+			 * example:
+			 * Bin mal weg...
+			 */
+			absenceMessage?: string;
+			/**
+			 * example:
+			 * true
+			 */
+			isInTeamAgency?: boolean;
+			agencies?: AgencyDTO[];
+			userRoles?: string[];
+			grantedAuthorities?: string[];
+			consultingTypes?: ConsultingTypeMap;
+		}
+		export interface UserSessionListResponseDTO {
+			sessions?: UserSessionResponseDTO[];
+		}
+		export interface UserSessionResponseDTO {
+			session?: SessionDTO;
+			chat?: UserChatDTO;
+			agency?: AgencyDTO;
+			consultant?: SessionConsultantForUserDTO;
+			latestMessage?: Date;
+		}
+	}
+}
+declare namespace Paths {
+	namespace AcceptEnquiry {
+		export interface HeaderParameters {
+			RCUserId: Parameters.RCUserId;
+		}
+		namespace Parameters {
+			export type RCUserId = string;
+			export type SessionId = number; // int64
+		}
+		export interface PathParameters {
+			sessionId: Parameters.SessionId /* int64 */;
+		}
+		namespace Responses {
+			export interface $200 {}
+			export interface $400 {}
+			export interface $401 {}
+			export interface $403 {}
+			export interface $409 {}
+			export interface $500 {}
+		}
+	}
+	namespace AssignSession {
+		namespace Parameters {
+			export type ConsultantId = string;
+			export type SessionId = number; // int64
+		}
+		export interface PathParameters {
+			sessionId: Parameters.SessionId /* int64 */;
+			consultantId: Parameters.ConsultantId;
+		}
+		namespace Responses {
+			export interface $200 {}
+			export interface $400 {}
+			export interface $401 {}
+			export interface $403 {}
+			export interface $409 {}
+			export interface $500 {}
+		}
+	}
+	namespace CreateChat {
+		export type RequestBody = UserService.Schemas.ChatDTO;
+		namespace Responses {
+			export type $201 = UserService.Schemas.CreateChatResponseDTO;
+			export interface $400 {}
+			export interface $403 {}
+			export interface $409 {}
+			export interface $500 {}
+		}
+	}
+	namespace CreateEnquiryMessage {
+		export interface HeaderParameters {
+			RCToken: Parameters.RCToken;
+			RCUserId: Parameters.RCUserId;
+		}
+		namespace Parameters {
+			export type RCToken = string;
+			export type RCUserId = string;
+			export type SessionId = number; // int64
+		}
+		export interface PathParameters {
+			sessionId: Parameters.SessionId /* int64 */;
+		}
+		export type RequestBody = UserService.Schemas.EnquiryMessageDTO;
+		namespace Responses {
+			export interface $201 {}
+			export interface $400 {}
+			export interface $401 {}
+			export interface $403 {}
+			export interface $409 {}
+			export interface $500 {}
+		}
+	}
+	namespace GetChat {
+		namespace Parameters {
+			export type ChatId = number; // int64
+		}
+		export interface PathParameters {
+			chatId: Parameters.ChatId /* int64 */;
+		}
+		namespace Responses {
+			export type $200 = UserService.Schemas.ChatInfoResponseDTO;
+			export interface $400 {}
+			export interface $401 {}
+			export interface $403 {}
+			export interface $404 {}
+			export interface $500 {}
+		}
+	}
+	namespace GetChatMembers {
+		namespace Parameters {
+			export type ChatId = number; // int64
+		}
+		export interface PathParameters {
+			chatId: Parameters.ChatId /* int64 */;
+		}
+		namespace Responses {
+			export type $200 = UserService.Schemas.ChatMembersResponseDTO;
+			export interface $400 {}
+			export interface $401 {}
+			export interface $403 {}
+			export interface $404 {}
+			export interface $409 {}
+			export interface $500 {}
+		}
+	}
+	namespace GetConsultants {
+		namespace Parameters {
+			export type AgencyId = number; // int64
+		}
+		export interface QueryParameters {
+			agencyId: Parameters.AgencyId /* int64 */;
+		}
+		namespace Responses {
+			export type $200 = UserService.Schemas.ConsultantResponseDTO[];
+			export interface $204 {}
+			export interface $400 {}
+			export interface $401 {}
+			export interface $403 {}
+			export interface $500 {}
+		}
+	}
+	namespace GetMonitoring {
+		namespace Parameters {
+			export type SessionId = number; // int64
+		}
+		export interface PathParameters {
+			sessionId: Parameters.SessionId /* int64 */;
+		}
+		namespace Responses {
+			export type $200 = UserService.Schemas.MonitoringDTO;
+			export interface $204 {}
+			export interface $400 {}
+			export interface $401 {}
+			export interface $403 {}
+			export interface $500 {}
+		}
+	}
+	namespace GetSessionsForAuthenticatedConsultant {
+		export interface HeaderParameters {
+			RCToken: Parameters.RCToken;
+		}
+		namespace Parameters {
+			export type Count = number;
+			export type Filter = string;
+			export type Offset = number;
+			export type RCToken = string;
+			export type Status = number;
+		}
+		export interface QueryParameters {
+			status?: Parameters.Status;
+			offset: Parameters.Offset;
+			count: Parameters.Count;
+			filter: Parameters.Filter;
+		}
+		namespace Responses {
+			export type $200 = UserService.Schemas.ConsultantSessionListResponseDTO;
+			export interface $204 {}
+			export interface $401 {}
+			export interface $403 {}
+			export interface $500 {}
+		}
+	}
+	namespace GetSessionsForAuthenticatedUser {
+		export interface HeaderParameters {
+			RCToken: Parameters.RCToken;
+		}
+		namespace Parameters {
+			export type RCToken = string;
+		}
+		namespace Responses {
+			export type $200 = UserService.Schemas.UserSessionListResponseDTO;
+			export interface $204 {}
+			export interface $400 {}
+			export interface $401 {}
+			export interface $403 {}
+			export interface $500 {}
+		}
+	}
+	namespace GetTeamSessionsForAuthenticatedConsultant {
+		export interface HeaderParameters {
+			RCToken: Parameters.RCToken;
+		}
+		namespace Parameters {
+			export type Count = number;
+			export type Filter = string;
+			export type Offset = number;
+			export type RCToken = string;
+		}
+		export interface QueryParameters {
+			offset: Parameters.Offset;
+			count: Parameters.Count;
+			filter: Parameters.Filter;
+		}
+		namespace Responses {
+			export type $200 = UserService.Schemas.ConsultantSessionListResponseDTO;
+			export interface $204 {}
+			export interface $401 {}
+			export interface $403 {}
+			export interface $500 {}
+		}
+	}
+	namespace GetUserData {
+		namespace Responses {
+			export type $200 = UserService.Schemas.UserDataResponseDTO;
+			export interface $400 {}
+			export interface $401 {}
+			export interface $403 {}
+			export interface $500 {}
+		}
+	}
+	namespace ImportAskers {
+		namespace Responses {
+			export interface $200 {}
+			export interface $400 {}
+			export interface $401 {}
+			export interface $500 {}
+		}
+	}
+	namespace ImportAskersWithoutSession {
+		namespace Responses {
+			export interface $200 {}
+			export interface $400 {}
+			export interface $401 {}
+			export interface $500 {}
+		}
+	}
+	namespace ImportConsultants {
+		namespace Responses {
+			export interface $200 {}
+			export interface $400 {}
+			export interface $401 {}
+			export interface $500 {}
+		}
+	}
+	namespace JoinChat {
+		namespace Parameters {
+			export type ChatId = number; // int64
+		}
+		export interface PathParameters {
+			chatId: Parameters.ChatId /* int64 */;
+		}
+		namespace Responses {
+			export interface $200 {}
+			export interface $400 {}
+			export interface $401 {}
+			export interface $403 {}
+			export interface $404 {}
+			export interface $409 {}
+			export interface $500 {}
+		}
+	}
+	namespace LeaveChat {
+		namespace Parameters {
+			export type ChatId = number; // int64
+		}
+		export interface PathParameters {
+			chatId: Parameters.ChatId /* int64 */;
+		}
+		namespace Responses {
+			export interface $200 {}
+			export interface $400 {}
+			export interface $401 {}
+			export interface $403 {}
+			export interface $404 {}
+			export interface $409 {}
+			export interface $500 {}
+		}
+	}
+	namespace RegisterNewConsultingType {
+		export interface HeaderParameters {
+			RCToken: Parameters.RCToken;
+			RCUserId: Parameters.RCUserId;
+		}
+		namespace Parameters {
+			export type RCToken = string;
+			export type RCUserId = string;
+		}
+		export type RequestBody = UserService.Schemas.NewRegistrationDto;
+		namespace Responses {
+			export type $201 = UserService.Schemas.NewRegistrationResponseDto;
+			export interface $400 {}
+			export interface $403 {}
+			export interface $409 {}
+			export interface $500 {}
+		}
+	}
+	namespace RegisterUser {
+		export type RequestBody = UserService.Schemas.UserDTO;
+		namespace Responses {
+			export type $201 = UserService.Schemas.CreateUserResponseDTO;
+			export interface $400 {}
+			export interface $403 {}
+			export interface $500 {}
+		}
+	}
+	namespace SendLiveEvent {
+		namespace Parameters {
+			export type RcGroupId = string;
+		}
+		export interface QueryParameters {
+			rcGroupId: Parameters.RcGroupId;
+		}
+		namespace Responses {
+			export interface $200 {}
+			export interface $400 {}
+			export interface $403 {}
+			export interface $409 {}
+			export interface $500 {}
+		}
+	}
+	namespace SendNewFeedbackMessageNotification {
+		export type RequestBody = UserService.Schemas.NewMessageNotificationDTO;
+		namespace Responses {
+			export interface $200 {}
+			export interface $400 {}
+			export interface $401 {}
+			export interface $409 {}
+			export interface $500 {}
+		}
+	}
+	namespace SendNewMessageNotification {
+		export type RequestBody = UserService.Schemas.NewMessageNotificationDTO;
+		namespace Responses {
+			export interface $200 {}
+			export interface $400 {}
+			export interface $401 {}
+			export interface $409 {}
+			export interface $500 {}
+		}
+	}
+	namespace StartChat {
+		namespace Parameters {
+			export type ChatId = number; // int64
+		}
+		export interface PathParameters {
+			chatId: Parameters.ChatId /* int64 */;
+		}
+		namespace Responses {
+			export interface $200 {}
+			export interface $400 {}
+			export interface $401 {}
+			export interface $403 {}
+			export interface $409 {}
+			export interface $500 {}
+		}
+	}
+	namespace StopChat {
+		namespace Parameters {
+			export type ChatId = number; // int64
+		}
+		export interface PathParameters {
+			chatId: Parameters.ChatId /* int64 */;
+		}
+		namespace Responses {
+			export interface $200 {}
+			export interface $400 {}
+			export interface $401 {}
+			export interface $403 {}
+			export interface $409 {}
+			export interface $500 {}
+		}
+	}
+	namespace UpdateAbsence {
+		export type RequestBody = UserService.Schemas.AbsenceDTO;
+		namespace Responses {
+			export interface $200 {}
+			export interface $400 {}
+			export interface $401 {}
+			export interface $403 {}
+			export interface $500 {}
+		}
+	}
+	namespace UpdateChat {
+		namespace Parameters {
+			export type ChatId = number; // int64
+		}
+		export interface PathParameters {
+			chatId: Parameters.ChatId /* int64 */;
+		}
+		export type RequestBody = UserService.Schemas.ChatDTO;
+		namespace Responses {
+			export type $200 = UserService.Schemas.UpdateChatResponseDTO;
+			export interface $400 {}
+			export interface $403 {}
+			export interface $409 {}
+			export interface $500 {}
+		}
+	}
+	namespace UpdateKey {
+		export type RequestBody = UserService.Schemas.MasterKeyDTO;
+		namespace Responses {
+			export interface $202 {}
+			export interface $401 {}
+			export interface $403 {}
+			export interface $409 {}
+			export interface $500 {}
+		}
+	}
+	namespace UpdateMonitoring {
+		namespace Parameters {
+			export type SessionId = number; // int64
+		}
+		export interface PathParameters {
+			sessionId: Parameters.SessionId /* int64 */;
+		}
+		export type RequestBody = UserService.Schemas.MonitoringDTO;
+		namespace Responses {
+			export interface $200 {}
+			export interface $400 {}
+			export interface $401 {}
+			export interface $403 {}
+			export interface $500 {}
+		}
+	}
+	namespace UpdatePassword {
+		export type RequestBody = UserService.Schemas.PasswordDTO;
+		namespace Responses {
+			export interface $200 {}
+			export interface $400 {}
+			export interface $401 {}
+			export interface $403 {}
+			export interface $500 {}
+		}
+	}
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,10 @@
 		"downlevelIteration": true,
 		"typeRoots": ["node_modules/@types"]
 	},
-	"include": ["src"]
+	"include": ["src"],
+	"ts-node": {
+		"compilerOptions": {
+			"module": "commonjs"
+		}
+	}
 }


### PR DESCRIPTION
## Proposed Changes

  - Add npm script `dtsgen` to generate TypeScript Types from OpenAPI specs of backend services
  - Add current generated `develop` types from backend

## Updating types

```
npm install
npm run dtsgen
```

then add and commit changed files in `src/generated/`