### PR TITLE
refactor(tests): properly clean up websocket mocks

### DIFF
--- a/cypress/support/websocket.ts
+++ b/cypress/support/websocket.ts
@@ -14,13 +14,8 @@ const mocks: { [key: string]: { server: Server; websocket: WebSocket } } = {};
 
 const cleanupMock = (url: string) => {
 	if (mocks[url]) {
-		if (
-			mocks[url].websocket.readyState ===
-				mocks[url].websocket.CONNECTING ||
-			mocks[url].websocket.readyState === mocks[url].websocket.OPEN
-		) {
-			mocks[url].server.stop();
-		}
+		mocks[url].websocket.close();
+		mocks[url].server.stop();
 		delete mocks[url];
 	}
 };
@@ -78,6 +73,12 @@ export const mockWebSocket = () => {
 				return new winWebSocket(url);
 			}
 		});
+	});
+
+	cy.on('window:before:unload', () => {
+		for (const url in mocks) {
+			cleanupMock(url);
+		}
 	});
 };
 


### PR DESCRIPTION
## Proposed Changes

- Cleanup websocket mocks before window unloads
- Close websocket before stopping server
- This hopefully helps with the flaky "WebSocket is already in CLOSING or CLOSED state" error
