### PR TITLE
fix: 🐛 spacing above message submit component

### DIFF
--- a/src/components/session/session.styles.scss
+++ b/src/components/session/session.styles.scss
@@ -77,13 +77,11 @@ $unreadButtonSize: 18px;
 		height: 100%;
 		overflow-x: hidden;
 		overflow-y: auto;
-		padding: $grid-base-three $grid-base-two 0;
-		margin-bottom: $grid-base-three;
+		padding: $grid-base-three $grid-base-two $grid-base-two;
 		background-color: $background-ochre;
 
 		@include breakpoint($fromMedium) {
-			padding: $grid-base-three $grid-base-three 0 $grid-base-three;
-			margin-bottom: $grid-base-four;
+			padding: $grid-base-three $grid-base-three $grid-base-two;
 		}
 
 		@include breakpoint($fromLarge) {

--- a/src/components/typingIndicator/typingIndicator.styles.scss
+++ b/src/components/typingIndicator/typingIndicator.styles.scss
@@ -1,11 +1,11 @@
-$indicator-height: 37px;
+$indicator-height: 29px;
 
 .typing-indicator {
 	display: flex;
 	position: absolute;
 	top: -$indicator-height;
 	width: 100%;
-	padding: $grid-base $grid-base-three;
+	padding: 4px $grid-base-three;
 	background-color: $background-ochre;
 	align-items: center;
 	z-index: 2;


### PR DESCRIPTION
## Proposed Changes

  - remove whitespace above submit interface
  - adjust padding and 'isTyping' sizing
