### PR TITLE
fix: 🐛 remove default outline of editable data inputfield

### DIFF
--- a/src/components/editableData/editableData.styles.scss
+++ b/src/components/editableData/editableData.styles.scss
@@ -24,6 +24,7 @@
 		&:focus-visible,
 		&:focus {
 			border-bottom: 1px solid $primary;
+			outline: none;
 		}
 
 		&::selection {


### PR DESCRIPTION
## Proposed Changes

  - remove default outline of editable data inputfield in focus state
