### PR TITLE
fix: 🐛 reset currentOffset on filter select

### DIFF
--- a/src/components/sessionsList/SessionsList.tsx
+++ b/src/components/sessionsList/SessionsList.tsx
@@ -477,6 +477,7 @@ export const SessionsList: React.FC = () => {
 	};
 
 	const handleSelect = (selectedOption) => {
+		setCurrentOffset(0);
 		setHasNoSessions(false);
 		setActiveSessionGroupId(null);
 		setFilterStatus(selectedOption.value);


### PR DESCRIPTION
Fixes empty loaded list instead of correct items because of wrong offset

## Proposed Changes

  - reset currentOffset when filter is (re-)select
