### PR TITLE
feat: [COBH-4055] allow escaping in markdownToDraft

### DIFF
--- a/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
+++ b/src/components/messageSubmitInterface/messageSubmitInterfaceComponent.tsx
@@ -61,7 +61,8 @@ import {
 	emojiPickerCustomClasses,
 	toolbarCustomClasses,
 	handleEditorBeforeInput,
-	handleEditorPastedText
+	handleEditorPastedText,
+	escapeMarkdownChars
 } from './richtextHelpers';
 import { ReactComponent as EmojiIcon } from '../../resources/img/icons/smiley-positive.svg';
 import { ReactComponent as FileDocIcon } from '../../resources/img/icons/file-doc.svg';
@@ -457,8 +458,10 @@ export const MessageSubmitInterfaceComponent = (
 		const contentState = currentEditorState
 			? currentEditorState.getCurrentContent()
 			: editorState.getCurrentContent();
-		const rawObject = convertToRaw(contentState);
-		const markdownString = draftToMarkdown(rawObject);
+		const rawObject = convertToRaw(escapeMarkdownChars(contentState));
+		const markdownString = draftToMarkdown(rawObject, {
+			escapeMarkdownCharacters: false
+		});
 		return markdownString.trim();
 	};
 

--- a/src/components/messageSubmitInterface/richtextHelpers.ts
+++ b/src/components/messageSubmitInterface/richtextHelpers.ts
@@ -1,4 +1,10 @@
-import { DraftHandleValue } from 'draft-js';
+import {
+	ContentState,
+	convertToRaw,
+	DraftHandleValue,
+	Modifier,
+	SelectionState
+} from 'draft-js';
 import sanitizeHtml from 'sanitize-html';
 
 export const emojiPickerCustomClasses = {
@@ -96,7 +102,6 @@ export const markdownToDraftDefaultOptions = {
 			inline: [
 				'autolink',
 				'backticks',
-				'escape',
 				'htmltag',
 				'links',
 				'newline',
@@ -121,4 +126,33 @@ export const sanitizeHtmlDefaultOptions = {
 		'br'
 	],
 	allowedAttributes: sanitizeHtml.defaults.allowedAttributes
+};
+
+/**
+ * Escape markdown characters typed by the user
+ * @param contentState
+ */
+export const escapeMarkdownChars = (contentState: ContentState) => {
+	let newContentState = contentState;
+	const rawDraftObject = convertToRaw(contentState);
+
+	rawDraftObject.blocks.forEach((block) => {
+		const selectionState = SelectionState.createEmpty(block.key);
+		let counter = 0;
+		newContentState = [...block.text].reduce(
+			(contentState, char, charIndex) => {
+				if (['*', '_', '~', '`'].indexOf(char) < 0) return contentState;
+
+				const selection = selectionState.merge({
+					focusOffset: charIndex + counter,
+					anchorOffset: charIndex + counter
+				});
+				counter++;
+				return Modifier.insertText(contentState, selection, '\\');
+			},
+			newContentState
+		);
+	});
+
+	return newContentState;
 };


### PR DESCRIPTION
Fixes #COBH-4055

## Proposed Changes

  - Allow escaping in markdownToDraft parsing
  - Custom markdown escaping logic for user input because build in method does not work for inline characters
