### PR TITLE
fix: [COBH-4070] Fixed overlay scroll on mobile devices

### DIFF
--- a/src/components/overlay/overlay.styles.scss
+++ b/src/components/overlay/overlay.styles.scss
@@ -47,13 +47,14 @@ $iconSizeLarge: 48px;
 		text-align: $overlay-text-align;
 		margin: auto;
 		padding: $grid-base-six $grid-base-three;
-		overflow: visible;
+		overflow: scroll;
 
 		@include breakpoint($fromLarge) {
 			width: 100%;
 			height: auto;
 			max-width: 720px;
 			padding: $grid-base-six;
+			overflow: visible;
 		}
 
 		animation: fadeIn linear 0.8s;


### PR DESCRIPTION
Fixes #COBH-4070

## Proposed Changes

  - Changed overflow for mobile devices to scroll because overlay could exceed display size
