### PR TITLE
feat: [COBH-4058] Removed image option because windows show images

### DIFF
--- a/src/utils/notificationHelpers.ts
+++ b/src/utils/notificationHelpers.ts
@@ -23,7 +23,7 @@ export const hasPermissions = (permission: NotificationPermission) => {
 
 export const requestPermissions = () => {
 	// Only ask for notification if not denied or granted already
-	if (hasPermissions(PERMISSION_DEFAULT)) {
+	if (isSupported() && hasPermissions(PERMISSION_DEFAULT)) {
 		Notification.requestPermission().then((permission) => {
 			if (permission === PERMISSION_GRANTED) {
 				sendNotification('Benachrichtigungen aktiviert!');
@@ -51,8 +51,7 @@ export const sendNotification = (
 	const notification = new Notification(title, {
 		...options,
 		tag: uuidv4(),
-		icon: '/logo192.png',
-		image: '/logo192.png'
+		icon: '/logo192.png'
 	});
 
 	notification.onshow = () => {


### PR DESCRIPTION
Fixes #COBH-4058

## Proposed Changes

  - Removed notification image because its not required and shows only the logo in bigger size
