### PR TITLE
fix: [DDO-37] fixed safari not always firing copy event

### DIFF
--- a/src/resources/scripts/config.ts
+++ b/src/resources/scripts/config.ts
@@ -4,7 +4,7 @@ export const apiUrlEnv: string = process.env.REACT_APP_API_URL;
 export const apiUrl = process.env.REACT_APP_API_URL
 	? 'https://' + apiUrlEnv
 	: '';
-export const uiUrl = process.env.REACT_APP_UI_URL || '';
+export const uiUrl = process.env.REACT_APP_UI_URL || window.location.origin;
 export const APP_PATH = 'app';
 
 export const config = {


### PR DESCRIPTION
Fixes #DDO-37

## Proposed Changes

  - Fixed safari only fires copy event on multiple clicks
  - Added new copy by range method to clipboardHelpers which should now support copying html content in older browsers too.
  - Added window.location.origin as fallback for uiUrl
