### PR TITLE
refactor: add prettier-plugin-organize-imports for standardization of…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13781,6 +13781,12 @@
 				}
 			}
 		},
+		"prettier-plugin-organize-imports": {
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-2.3.4.tgz",
+			"integrity": "sha512-R8o23sf5iVL/U71h9SFUdhdOEPsi3nm42FD/oDYIZ2PQa4TNWWuWecxln6jlIQzpZTDMUeO1NicJP6lLn2TtRw==",
+			"dev": true
+		},
 		"pretty-bytes": {
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
 		"npm-run-all": "^4.1.5",
 		"prettier": "2.3.1",
 		"prettier-eslint-cli": "5.0.1",
+		"prettier-plugin-organize-imports": "^2.3.4",
 		"serve": "^12.0.0",
 		"standard-version": "^9.3.2",
 		"stylelint": "^14.3.0",


### PR DESCRIPTION
- add prettier-plugin-organize-imports for standardization of import order
- ⚠️ every other PR should be merged before
- ⚠️ a complete project wide run of the plugin should be done during the merge
