### PR TITLE
fix: prevent from displaying release notes when isn't markdown

### DIFF
--- a/cypress/integration/release-notes.spec.ts
+++ b/cypress/integration/release-notes.spec.ts
@@ -27,7 +27,10 @@ describe('release-note', () => {
 		cy.fixture('releaseNote.md').then((content) => {
 			cy.willReturn('releases', {
 				body: content,
-				statusCode: 200
+				statusCode: 200,
+				headers: {
+					'Content-Type': 'text/markdown'
+				}
 			});
 		});
 
@@ -54,7 +57,10 @@ describe('release-note', () => {
 		cy.fixture('releaseNote.md').then((content) => {
 			cy.willReturn('releases', {
 				body: content,
-				statusCode: 200
+				statusCode: 200,
+				headers: {
+					'Content-Type': 'text/markdown'
+				}
 			});
 		});
 
@@ -77,6 +83,24 @@ describe('release-note', () => {
 	});
 
 	it('should not show the release note overlay if there is no file', () => {
+		cy.fastLogin({
+			username: USER_CONSULTANT
+		});
+		cy.wait('@consultingTypeServiceBaseBasic');
+
+		cy.get('.releaseNote').should('not.exist');
+	});
+
+	it("should not show the release note overlay if there isn't a markdown", () => {
+		cy.fixture('releaseNote.md').then((content) => {
+			cy.willReturn('releases', {
+				body: '<html></html>',
+				statusCode: 200,
+				headers: {
+					'Content-Type': 'text/text'
+				}
+			});
+		});
 		cy.fastLogin({
 			username: USER_CONSULTANT
 		});

--- a/src/components/releaseNote/ReleaseNote.tsx
+++ b/src/components/releaseNote/ReleaseNote.tsx
@@ -29,8 +29,11 @@ export const ReleaseNote: React.FC<ReleaseNoteProps> = () => {
 		const response = await fetch(
 			`${config.urls.releases}/v${packageInfo.version}.md`
 		);
+		const isMarkdown = response.headers
+			.get('content-type')
+			?.match(/markdown/i);
 
-		if (response.ok) {
+		if (response.ok && isMarkdown) {
 			const markdownText = await response.text();
 
 			const rawMarkdownToDraftObject = markdownToDraft(markdownText);


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - When the release notes isn't available it tries to show the file index.html 
