### PR TITLE
feat: add fallback message when no agency is found

### DIFF
--- a/src/components/registration/RegistrationForm.tsx
+++ b/src/components/registration/RegistrationForm.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useState, useEffect, useCallback } from 'react';
 import { translate } from '../../utils/translate';
+import { Text } from '../text/Text';
 import { Button, BUTTON_TYPES } from '../button/Button';
 import { CheckboxItem, Checkbox } from '../checkbox/Checkbox';
 import { buttonItemSubmit } from './registrationHelpers';
@@ -275,6 +276,18 @@ export const RegistrationForm = ({
 							)}
 							agencyData={preselectedAgencyData}
 						/>
+					)}
+
+				{consultingType?.registration.autoSelectPostcode &&
+					!preselectedAgencyData && (
+						<div className="registrationForm__no-agency-found">
+							<Text
+								text={translate(
+									'registration.agencySelection.noAgencies'
+								)}
+								type="infoLargeAlternative"
+							/>
+						</div>
 					)}
 
 				<div className="registrationForm__dataProtection">

--- a/src/components/registration/registrationForm.styles.scss
+++ b/src/components/registration/registrationForm.styles.scss
@@ -67,6 +67,10 @@ $registration-form-headline-margin-bottom: 24px;
 		max-width: 690px;
 	}
 
+	&__no-agency-found {
+		margin-top: 28px;
+	}
+
 	.select__wrapper {
 		padding: 0;
 		margin: 0 auto;


### PR DESCRIPTION
## Proposed Changes
In the case of we don't have any valid agencies for a given topic currently we don't show any message to the user, so this PR will add a message in that case

Before:
<img width="1032" alt="image" src="https://user-images.githubusercontent.com/1266477/179913724-8f378640-7df5-45d4-9339-ccab6eb72e71.png">

After: 
<img width="464" alt="image" src="https://user-images.githubusercontent.com/1266477/179913849-f9baf512-38f2-4eba-8594-969731a9af28.png">
