### PR TITLE
feat: add a warning when no topic is selected and prevent the request

### DIFF
--- a/src/components/agencySelection/AgencySelection.tsx
+++ b/src/components/agencySelection/AgencySelection.tsx
@@ -128,12 +128,17 @@ export const AgencySelection = (props: AgencySelectionProps) => {
 					setIsLoading(true);
 					setSelectedAgency(null);
 					setPostcodeFallbackLink('');
-					const isValidInTopicRegistration =
+					// When we have the topics in in registration enabled to prevent for us doing the request
+					// we need to ensure that we've the mainTopicId is set
+					const isValidWhenTopicInRegistrationIsActive =
 						(tenantData?.settings?.topicsInRegistrationEnabled &&
 							props.mainTopicId) ||
 						!tenantData?.settings?.topicsInRegistrationEnabled;
 
-					if (validPostcode() && isValidInTopicRegistration) {
+					if (
+						validPostcode() &&
+						isValidWhenTopicInRegistrationIsActive
+					) {
 						const agencies = (
 							await apiAgencySelection({
 								postcode: selectedPostcode,

--- a/src/components/agencySelection/AgencySelection.tsx
+++ b/src/components/agencySelection/AgencySelection.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 import { useEffect, useState } from 'react';
 import {
 	AgencyDataInterface,
-	ConsultingTypeBasicInterface
+	ConsultingTypeBasicInterface,
+	useTenant
 } from '../../globalState';
 import { translate } from '../../utils/translate';
 import { apiAgencySelection, FETCH_ERRORS } from '../../api';
@@ -41,6 +42,7 @@ export interface AgencySelectionProps {
 }
 
 export const AgencySelection = (props: AgencySelectionProps) => {
+	const tenantData = useTenant();
 	const [isLoading, setIsLoading] = useState(false);
 	const [postcodeFallbackLink, setPostcodeFallbackLink] = useState('');
 	const [proposedAgencies, setProposedAgencies] = useState<
@@ -126,7 +128,12 @@ export const AgencySelection = (props: AgencySelectionProps) => {
 					setIsLoading(true);
 					setSelectedAgency(null);
 					setPostcodeFallbackLink('');
-					if (validPostcode()) {
+					const isValidInTopicRegistration =
+						(tenantData?.settings?.topicsInRegistrationEnabled &&
+							props.mainTopicId) ||
+						!tenantData?.settings?.topicsInRegistrationEnabled;
+
+					if (validPostcode() && isValidInTopicRegistration) {
 						const agencies = (
 							await apiAgencySelection({
 								postcode: selectedPostcode,

--- a/src/components/formAccordion/FormAccordion.tsx
+++ b/src/components/formAccordion/FormAccordion.tsx
@@ -21,6 +21,7 @@ import {
 	AccordionItemValidity,
 	stateData,
 	VALIDITY_INITIAL,
+	VALIDITY_INVALID,
 	VALIDITY_VALID
 } from '../registration/registrationHelpers';
 import {
@@ -99,15 +100,12 @@ export const FormAccordion = ({
 		);
 	}, [validity]); // eslint-disable-line react-hooks/exhaustive-deps
 
-	const handleValidity = useCallback(
-		(key, value) => {
-			setValidity({
-				...validity,
-				[key]: value
-			});
-		},
-		[validity]
-	);
+	const handleValidity = useCallback((key, value) => {
+		setValidity((prevState) => ({
+			...prevState,
+			[key]: value
+		}));
+	}, []);
 
 	useEffect(() => {
 		if (isUsernameAlreadyInUse) {
@@ -221,9 +219,16 @@ export const FormAccordion = ({
 					preselectedAgency={preselectedAgencyData}
 					onAgencyChange={(agency) => setAgency(agency)}
 					hideExternalAgencies
-					onValidityChange={(validity) =>
-						handleValidity('agency', validity)
-					}
+					onValidityChange={(validity) => {
+						if (
+							tenantData?.settings?.topicsInRegistrationEnabled &&
+							!mainTopicId &&
+							validity !== VALIDITY_INITIAL
+						) {
+							handleValidity('mainTopic', VALIDITY_INVALID);
+						}
+						handleValidity('agency', validity);
+					}}
 					agencySelectionNote={registrationNotes?.agencySelection}
 					mainTopicId={mainTopicId}
 				/>


### PR DESCRIPTION
## Proposed Changes
When we have the feature topics enabled and when we want register and the user skips right away to the agency selection and not select a topic we can't request the agencies because we need the topic to search the agency

https://user-images.githubusercontent.com/1266477/179943107-4ee743c6-9a40-43b5-b89c-53059efa5ea8.mov


