### PR TITLE
feat: add the copy links (qr code and link) to group chages info

### DIFF
--- a/src/components/groupChat/GroupChatCopyLinks.tsx
+++ b/src/components/groupChat/GroupChatCopyLinks.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { useCallback, useContext } from 'react';
+import {
+	NotificationsContext,
+	NOTIFICATION_TYPE_SUCCESS
+} from '../../globalState';
+import { CopyIcon } from '../../resources/img/icons';
+import { config } from '../../resources/scripts/config';
+import { copyTextToClipboard } from '../../utils/clipboardHelpers';
+import { translate } from '../../utils/translate';
+import { GenerateQrCode } from '../generateQrCode/GenerateQrCode';
+import './groupChatCopyLinks.scss';
+
+type GroupChatCopyLinksProps = {
+	groupChatId: string;
+};
+
+export const GroupChatCopyLinks = ({
+	groupChatId
+}: GroupChatCopyLinksProps) => {
+	const url = `${config.urls.registration}?gcid=${groupChatId}`;
+	const { addNotification } = useContext(NotificationsContext);
+
+	const copyRegistrationLink = useCallback(async () => {
+		await copyTextToClipboard(url, () => {
+			addNotification({
+				notificationType: NOTIFICATION_TYPE_SUCCESS,
+
+				title: translate('groupChat.copy.link.notification.title'),
+				text: translate('groupChat.copy.link.notification.text')
+			});
+		});
+	}, [url, addNotification]);
+
+	return (
+		<div className="GroupChatCopyLinks">
+			<div className="GroupChatCopyLinks_qrCode">
+				<GenerateQrCode
+					url={url}
+					headline={translate('groupChat.qrCode.headline')}
+					text={translate('groupChat.qrCode.text')}
+					filename={`group-chat-${groupChatId}`}
+				/>
+			</div>
+			<div className="GroupChatCopyLinks_copyLink">
+				<span
+					className="profile__data__copy_registration_link text--nowrap text--tertiary primary mr--2"
+					role="button"
+					onClick={copyRegistrationLink}
+					title={translate('groupChat.copy.link.title')}
+				>
+					<CopyIcon className={`copy icn--s`} />{' '}
+					{translate('groupChat.copy.link.text')}
+				</span>
+			</div>
+		</div>
+	);
+};

--- a/src/components/groupChat/GroupChatInfo.tsx
+++ b/src/components/groupChat/GroupChatInfo.tsx
@@ -44,12 +44,16 @@ import { useResponsive } from '../../hooks/useResponsive';
 import { Tag } from '../tag/Tag';
 import { useSession } from '../../hooks/useSession';
 import { useSearchParam } from '../../hooks/useSearchParams';
+import { GroupChatCopyLinks } from './GroupChatCopyLinks';
 
 const stopChatButtonSet: ButtonItem = {
 	label: translate('groupChat.stopChat.securityOverlay.button1Label'),
 	function: OVERLAY_FUNCTIONS.CLOSE,
 	type: BUTTON_TYPES.PRIMARY
 };
+
+// TODO: Adding the proper feature flag to the file and replace this one
+const groupChatFeatureFlagEnabled = false;
 
 export const GroupChatInfo = () => {
 	const { rcGroupId: groupIdFromParam } = useParams();
@@ -245,6 +249,14 @@ export const GroupChatInfo = () => {
 							)}
 							type="divider"
 						/>
+
+						{groupChatFeatureFlagEnabled && (
+							<div className="profile__groupChatContainer">
+								<GroupChatCopyLinks
+									groupChatId={activeSession.rid}
+								/>
+							</div>
+						)}
 						{subscriberList ? (
 							subscriberList.map((subscriber, index) => (
 								<div

--- a/src/components/groupChat/groupChatCopyLinks.scss
+++ b/src/components/groupChat/groupChatCopyLinks.scss
@@ -1,0 +1,10 @@
+.GroupChatCopyLinks {
+	display: flex;
+	gap: 18px;
+	flex-wrap: wrap;
+	align-items: center;
+}
+
+.profile__content .profile__groupChatContainer + .profile__data__item {
+	margin-top: 29px;
+}

--- a/src/resources/scripts/i18n/de/groupChat.ts
+++ b/src/resources/scripts/i18n/de/groupChat.ts
@@ -76,7 +76,15 @@ const groupChat = {
 	'stopped.overlay.button2Label': 'Logout',
 	'updateSuccess.overlayHeadline':
 		'Ihre Änderungen wurden erfolgreich gespeichert.',
-	'updateSuccess.overlay.button1Label': 'Schließen'
+	'updateSuccess.overlay.button1Label': 'Schließen',
+	'copy.link.title': 'Einladungslink in Zwischenablage kopieren',
+	'copy.link.text': 'Link kopieren',
+	'copy.link.notification.title': 'Link kopiert',
+	'copy.link.notification.text':
+		'Einladungslink zum Gruppenchat in Zwischenablage kopiert!',
+	'qrCode.headline': 'Einladungslink QR-Code',
+	'qrCode.text':
+		'Wenn Sie Ihren QR-Code mit jemandem teilen, kann diese Person ihn mit der Handykamera scannen, um direkt am Video-Call teilzunehmen. Alternativ können Sie den Code auch herunterladen.'
 };
 
 export default groupChat;


### PR DESCRIPTION
Adding the copy links to group chat info to allow us login and join right away to the chat

**Still missing the feature toggle and one text(check the translation: copy.link.notification.text) that I've asked Lea to provide**



<img width="760" alt="image" src="https://user-images.githubusercontent.com/1266477/183099295-76865447-45a8-47f1-9f41-f98a442cf819.png">
