### PR TITLE
fix: back buttons in the group chat

### DIFF
--- a/src/components/groupChat/CreateChatView.tsx
+++ b/src/components/groupChat/CreateChatView.tsx
@@ -189,11 +189,12 @@ export const CreateGroupChatView = (props) => {
 
 	const handleBackButton = () => {
 		if (isEditGroupChatMode) {
-			history.push(`${listPath}/${activeSession.item.groupId}/${
-				activeSession.item.id
-			}
-				${prevPathIsGroupChatInfo ? '/groupChatInfo' : ''}
-				${getSessionListTab()}`);
+			const pathInfo =
+				(prevPathIsGroupChatInfo ? '/groupChatInfo' : '') +
+				getSessionListTab();
+			history.push(
+				`${listPath}/${activeSession.item.groupId}/${activeSession.item.id}${pathInfo}`
+			);
 		}
 	};
 
@@ -357,12 +358,11 @@ export const CreateGroupChatView = (props) => {
 				overlayItem === createChatSuccessOverlayItem ||
 				overlayItem === updateChatSuccessOverlayItem
 			) {
+				const pathInfo =
+					(prevPathIsGroupChatInfo ? '/groupChatInfo' : '') +
+					getSessionListTab();
 				history.push(
-					`${listPath}/${activeSession.item.groupId}/${
-						activeSession.item.id
-					}${
-						prevPathIsGroupChatInfo ? '/groupChatInfo' : ''
-					}${getSessionListTab()}`
+					`${listPath}/${activeSession.item.groupId}/${activeSession.item.id}${pathInfo}`
 				);
 			} else {
 				setOverlayActive(false);


### PR DESCRIPTION
Fixes #
When we entered in the group chat info and we hit the "cancel" button since the path was wrong the page looks empty, this PR fixes that 