### PR TITLE
fix: start using the path as classname to prevent of using other tabs

### DIFF
--- a/src/components/app/NavigationBar.tsx
+++ b/src/components/app/NavigationBar.tsx
@@ -24,6 +24,7 @@ export interface NavigationBarProps {
 	routerConfig: any;
 }
 
+const REGEX_DASH = /\//g;
 export const NavigationBar = ({
 	onLogout,
 	routerConfig
@@ -99,18 +100,10 @@ export const NavigationBar = ({
 		'/sessions/consultant/teamSessionView': unreadTeamSessions.length
 	};
 
-	const resolveClassnameForWalkthrough = (index) => {
-		switch (index) {
-			case 0:
-				return 'walkthrough_step_1';
-			case 1:
-				return 'walkthrough_step_3';
-			case 2:
-				return 'walkthrough_step_5';
-			case 3:
-				return 'walkthrough_step_6';
-		}
-	};
+	const pathToClassNameInWalkThrough = React.useCallback((to: string) => {
+		const value = to.replace(REGEX_DASH, '-').toLowerCase().slice(1);
+		return value ? `walkthrough-${value}` : '';
+	}, []);
 
 	return (
 		<div className="navigation__wrapper">
@@ -129,8 +122,8 @@ export const NavigationBar = ({
 						.map((item, index) => (
 							<Link
 								key={index}
-								className={`navigation__item ${resolveClassnameForWalkthrough(
-									index
+								className={`navigation__item ${pathToClassNameInWalkThrough(
+									item.to
 								)} ${
 									location.pathname.indexOf(item.to) !== -1 &&
 									'navigation__item--active'

--- a/src/components/walkthrough/Walkthrough.tsx
+++ b/src/components/walkthrough/Walkthrough.tsx
@@ -68,7 +68,7 @@ export const Walkthrough = () => {
 				showStepNumbers: false
 			}}
 			onBeforeChange={(nextStepIndex) => {
-				if (stepsData[nextStepIndex].path) {
+				if (stepsData[nextStepIndex]?.path) {
 					history.push(stepsData[nextStepIndex].path);
 					onChangeStep();
 				}

--- a/src/components/walkthrough/steps.ts
+++ b/src/components/walkthrough/steps.ts
@@ -20,7 +20,7 @@ const steps = ({ hasTeamAgency }: StepsFeatureFlag): StepsData[] =>
 		},
 		{
 			title: translate('walkthrough.step.1.title'),
-			element: '.walkthrough_step_1',
+			element: '.walkthrough-sessions-consultant-sessionpreview',
 			intro: translate('walkthrough.step.1'),
 			path: '/sessions/consultant/sessionPreview'
 		},
@@ -32,7 +32,7 @@ const steps = ({ hasTeamAgency }: StepsFeatureFlag): StepsData[] =>
 		},
 		{
 			title: translate('walkthrough.step.3.title'),
-			element: '.walkthrough_step_3',
+			element: '.walkthrough-sessions-consultant-sessionview',
 			intro: translate('walkthrough.step.3'),
 			path: '/sessions/consultant/sessionView'
 		},
@@ -44,23 +44,16 @@ const steps = ({ hasTeamAgency }: StepsFeatureFlag): StepsData[] =>
 		},
 		hasTeamAgency && {
 			title: translate('walkthrough.step.5.title'),
-			element: '.walkthrough_step_5',
+			element: '.walkthrough-sessions-consultant-teamsessionview',
 			intro: translate('walkthrough.step.5'),
 			path: '/sessions/consultant/teamSessionView'
 		},
 		{
 			title: translate('walkthrough.step.6.title'),
-			element: '.walkthrough_step_6',
+			element: '.walkthrough-profile',
 			intro: translate('walkthrough.step.6'),
 			path: '/profile/allgemeines'
 		}
-	]
-		.filter(Boolean)
-		.map((step, i) => {
-			return {
-				...step,
-				element: step.element ? '.walkthrough_step_' + i : step.element
-			};
-		});
+	].filter(Boolean);
 
 export default steps;


### PR DESCRIPTION
Fixes #
Starting using the path to add the classname to the walkthrough instead of an index
