### PR TITLE
feat: adding the new api to retrieve the settings from the server

### DIFF
--- a/src/api/apiAgencyLanguages.ts
+++ b/src/api/apiAgencyLanguages.ts
@@ -4,7 +4,8 @@ import { fetchData, FETCH_METHODS } from './fetchData';
 import { AgencyLanguagesInterface } from '../globalState';
 
 export const apiAgencyLanguages = async (
-	agencyId: number
+	agencyId: number,
+	useMultiTenancyWithSingleDomain: boolean
 ): Promise<AgencyLanguagesInterface> => {
 	const url = config.endpoints.consultantsLanguages + '?agencyId=' + agencyId;
 
@@ -13,7 +14,7 @@ export const apiAgencyLanguages = async (
 		method: FETCH_METHODS.GET,
 		skipAuth: true,
 		responseHandling: [],
-		...(config.useMultiTenancyWithSingleDomain && {
+		...(useMultiTenancyWithSingleDomain && {
 			headersData: { agencyId }
 		})
 	}).then((result) => {

--- a/src/api/apiGetTenantTheming.ts
+++ b/src/api/apiGetTenantTheming.ts
@@ -2,16 +2,22 @@ import { fetchData, FETCH_METHODS, FETCH_ERRORS } from './fetchData';
 import { config } from '../resources/scripts/config';
 import { TenantDataInterface } from '../globalState/interfaces/TenantDataInterface';
 
-const MAIN_TENANT_SINGLE_DOMAIN = 'app';
-export const apiGetTenantTheming = async (params: {
+interface GetTenantThemingParams {
 	subdomain: string;
 	useMultiTenancyWithSingleDomain: boolean;
-}): Promise<TenantDataInterface> =>
+	mainTenantSubdomainForSingleDomain: string;
+}
+
+export const apiGetTenantTheming = async ({
+	subdomain,
+	useMultiTenancyWithSingleDomain,
+	mainTenantSubdomainForSingleDomain
+}: GetTenantThemingParams): Promise<TenantDataInterface> =>
 	fetchData({
 		url: `${config.endpoints.tenantServiceBase}/public/${
-			params.useMultiTenancyWithSingleDomain
-				? MAIN_TENANT_SINGLE_DOMAIN
-				: params.subdomain
+			useMultiTenancyWithSingleDomain
+				? mainTenantSubdomainForSingleDomain
+				: subdomain
 		}`,
 		method: FETCH_METHODS.GET,
 		skipAuth: true,

--- a/src/api/apiGetTenantTheming.ts
+++ b/src/api/apiGetTenantTheming.ts
@@ -5,10 +5,11 @@ import { TenantDataInterface } from '../globalState/interfaces/TenantDataInterfa
 const MAIN_TENANT_SINGLE_DOMAIN = 'app';
 export const apiGetTenantTheming = async (params: {
 	subdomain: string;
+	useMultiTenancyWithSingleDomain: boolean;
 }): Promise<TenantDataInterface> =>
 	fetchData({
 		url: `${config.endpoints.tenantServiceBase}/public/${
-			config.useMultiTenancyWithSingleDomain
+			params.useMultiTenancyWithSingleDomain
 				? MAIN_TENANT_SINGLE_DOMAIN
 				: params.subdomain
 		}`,

--- a/src/api/apiPostRegistration.ts
+++ b/src/api/apiPostRegistration.ts
@@ -1,14 +1,15 @@
 import { autoLogin } from '../components/registration/autoLogin';
 import { removeAllCookies } from '../components/sessionCookie/accessSessionCookie';
 import { TenantDataInterface } from '../globalState/interfaces/TenantDataInterface';
-import { config } from '../resources/scripts/config';
 import { ensureTenantSettings } from '../utils/tenantHelpers';
 import { FETCH_ERRORS, FETCH_METHODS, fetchData } from './fetchData';
 
 export const apiPostRegistration = (
 	url: string,
 	data: { agencyId?: string },
-	tenant?: TenantDataInterface
+	useMultiTenancyWithSingleDomain: boolean,
+	enableBudibaseSSO: boolean,
+	tenant: TenantDataInterface
 ): Promise<any> => {
 	removeAllCookies(['useInformal']);
 	return fetchData({
@@ -16,7 +17,7 @@ export const apiPostRegistration = (
 		method: FETCH_METHODS.POST,
 		bodyData: JSON.stringify(data),
 		skipAuth: true,
-		...(config.useMultiTenancyWithSingleDomain && {
+		...(useMultiTenancyWithSingleDomain && {
 			headersData: { agencyId: data.agencyId }
 		}),
 		responseHandling: [FETCH_ERRORS.CATCH_ALL_WITH_RESPONSE]
@@ -25,7 +26,8 @@ export const apiPostRegistration = (
 			username: data['username'],
 			password: decodeURIComponent(data['password']),
 			redirect: false,
-			...ensureTenantSettings(tenant?.settings)
+			enableBudibaseSSO,
+			...ensureTenantSettings(tenant?.settings, enableBudibaseSSO)
 		})
 	);
 };

--- a/src/api/apiServerSettings.ts
+++ b/src/api/apiServerSettings.ts
@@ -1,0 +1,11 @@
+import { config } from '../resources/scripts/config';
+import { fetchData, FETCH_METHODS } from './fetchData';
+import { ServerAppConfigInterface } from '../globalState';
+
+export const apiServerSettings = async (): Promise<ServerAppConfigInterface> =>
+	fetchData({
+		url: config.endpoints.serviceSettings,
+		method: FETCH_METHODS.GET,
+		skipAuth: true,
+		responseHandling: []
+	});

--- a/src/components/agencySelection/AgencyLanguages.tsx
+++ b/src/components/agencySelection/AgencyLanguages.tsx
@@ -4,6 +4,7 @@ import { translate } from '../../utils/translate';
 import { isUniqueLanguage } from '../profile/profileHelpers';
 import './agencyLanguages.styles';
 import { FixedLanguagesContext } from '../../globalState/provider/FixedLanguagesProvider';
+import { useAppConfigContext } from '../../globalState/context/useAppConfig';
 
 interface AgencyLanguagesProps {
 	agencyId: number;
@@ -12,6 +13,7 @@ interface AgencyLanguagesProps {
 export const AgencyLanguages: React.FC<AgencyLanguagesProps> = ({
 	agencyId
 }) => {
+	const { settings } = useAppConfigContext();
 	const fixedLanguages = useContext(FixedLanguagesContext);
 	const [isAllShown, setIsAllShown] = useState(false);
 	const [languages, setLanguages] = useState<string[]>([...fixedLanguages]);
@@ -19,7 +21,10 @@ export const AgencyLanguages: React.FC<AgencyLanguagesProps> = ({
 	useEffect(() => {
 		// async wrapper
 		const getLanguagesFromApi = async () => {
-			const response = await apiAgencyLanguages(agencyId).catch(() => {
+			const response = await apiAgencyLanguages(
+				agencyId,
+				settings?.multiTenancyWithSingleDomainEnabled
+			).catch(() => {
 				/* intentional, falls back to fixed languages */
 			});
 
@@ -33,7 +38,11 @@ export const AgencyLanguages: React.FC<AgencyLanguagesProps> = ({
 		};
 
 		getLanguagesFromApi();
-	}, [agencyId, fixedLanguages]);
+	}, [
+		agencyId,
+		fixedLanguages,
+		settings?.multiTenancyWithSingleDomainEnabled
+	]);
 
 	const languagesSelection = languages.slice(0, 2);
 	const difference = languages.length - languagesSelection.length;

--- a/src/components/app/AuthenticatedApp.tsx
+++ b/src/components/app/AuthenticatedApp.tsx
@@ -23,6 +23,8 @@ import { requestPermissions } from '../../utils/notificationHelpers';
 import { RocketChatSubscriptionsProvider } from '../../globalState/provider/RocketChatSubscriptionsProvider';
 import { RocketChatUnreadProvider } from '../../globalState/provider/RocketChatUnreadProvider';
 import { RocketChatPublicSettingsProvider } from '../../globalState/provider/RocketChatPublicSettingsProvider';
+import { apiServerSettings } from '../../api/apiServerSettings';
+import { useAppConfigContext } from '../../globalState/context/useAppConfig';
 
 interface AuthenticatedAppProps {
 	onAppReady: Function;
@@ -37,6 +39,7 @@ export const AuthenticatedApp = ({
 	spokenLanguages,
 	legalLinks
 }: AuthenticatedAppProps) => {
+	const { settings, setServerSettings } = useAppConfigContext();
 	const { setConsultingTypes } = useContext(ConsultingTypesContext);
 	const { userData, setUserData } = useContext(UserDataContext);
 
@@ -60,17 +63,28 @@ export const AuthenticatedApp = ({
 			setUserDataRequested(true);
 			handleTokenRefresh(false)
 				.then(() => {
-					Promise.all([apiGetUserData(), apiGetConsultingTypes()])
-						.then(([userProfileData, consultingTypes]) => {
-							// set informal / formal cookie depending on the given userdata
-							setValueInCookie(
-								'useInformal',
-								!userProfileData.formalLanguage ? '1' : ''
-							);
-							setUserData(userProfileData);
-							setConsultingTypes(consultingTypes);
-							setAppReady(true);
-						})
+					Promise.all([
+						apiGetUserData(),
+						apiGetConsultingTypes(),
+						settings.useApiClusterSettings && apiServerSettings()
+					])
+						.then(
+							([
+								userProfileData,
+								consultingTypes,
+								serverSettings
+							]) => {
+								// set informal / formal cookie depending on the given userdata
+								setValueInCookie(
+									'useInformal',
+									!userProfileData.formalLanguage ? '1' : ''
+								);
+								setUserData(userProfileData);
+								setConsultingTypes(consultingTypes);
+								setServerSettings(serverSettings || {});
+								setAppReady(true);
+							}
+						)
 						.catch((error) => {
 							setLoading(false);
 							console.log(error);
@@ -80,7 +94,13 @@ export const AuthenticatedApp = ({
 					setLoading(false);
 				});
 		}
-	}, [userDataRequested, setUserData, setConsultingTypes]);
+	}, [
+		userDataRequested,
+		setUserData,
+		setConsultingTypes,
+		settings.useApiClusterSettings,
+		setServerSettings
+	]);
 
 	useEffect(() => {
 		onAppReady();

--- a/src/components/app/RouterConfig.tsx
+++ b/src/components/app/RouterConfig.tsx
@@ -20,7 +20,11 @@ import { GroupChatInfo } from '../groupChat/GroupChatInfo';
 import { Appointments } from '../appointment/Appointments';
 import VideoConference from '../videoConference/VideoConference';
 import { config } from '../../resources/scripts/config';
-import { AUTHORITIES, hasUserAuthority } from '../../globalState';
+import {
+	AppConfigInterface,
+	AUTHORITIES,
+	hasUserAuthority
+} from '../../globalState';
 import { Booking } from '../booking/booking';
 import { BookingCancellation } from '../booking/bookingCancellation';
 import { BookingEvents } from '../booking/bookingEvents';
@@ -51,11 +55,14 @@ const showAppointmentsMenuItem = (userData, consultingTypes, sessionsData) => {
 	return showAppointmentsMenu(userData, sessionsData);
 };
 
-const isVideoAppointmentsEnabled = (userData, consultingTypes) =>
-	!config.disableVideoAppointments &&
-	hasVideoCallFeature(userData, consultingTypes);
+const isVideoAppointmentsEnabled = (
+	userData,
+	consultingTypes,
+	disableVideoAppointments
+) =>
+	!disableVideoAppointments && hasVideoCallFeature(userData, consultingTypes);
 
-export const RouterConfigUser = (): any => {
+export const RouterConfigUser = (settings: AppConfigInterface): any => {
 	return {
 		navigation: [
 			{
@@ -156,7 +163,7 @@ export const RouterConfigUser = (): any => {
 	};
 };
 
-export const RouterConfigConsultant = (): any => {
+export const RouterConfigConsultant = (settings: AppConfigInterface): any => {
 	return {
 		plainRoutes: [
 			{
@@ -183,7 +190,12 @@ export const RouterConfigConsultant = (): any => {
 				}
 			},
 			{
-				condition: isVideoAppointmentsEnabled,
+				condition: (userData, consultingTypes) =>
+					isVideoAppointmentsEnabled(
+						userData,
+						consultingTypes,
+						settings.disableVideoAppointments
+					),
 				to: '/termine',
 				icon: <CalendarIcon className="navigation__icon" />,
 				titleKeys: {
@@ -289,7 +301,12 @@ export const RouterConfigConsultant = (): any => {
 				component: Profile
 			},
 			{
-				condition: isVideoAppointmentsEnabled,
+				condition: (userData, consultingTypes) =>
+					isVideoAppointmentsEnabled(
+						userData,
+						consultingTypes,
+						settings.disableVideoAppointments
+					),
 				path: '/termine',
 				exact: false,
 				component: Appointments
@@ -317,7 +334,9 @@ export const RouterConfigConsultant = (): any => {
 	};
 };
 
-export const RouterConfigTeamConsultant = (): any => {
+export const RouterConfigTeamConsultant = (
+	settings: AppConfigInterface
+): any => {
 	return {
 		plainRoutes: [
 			{
@@ -352,7 +371,12 @@ export const RouterConfigTeamConsultant = (): any => {
 				}
 			},
 			{
-				condition: isVideoAppointmentsEnabled,
+				condition: (userData, consultingTypes) =>
+					isVideoAppointmentsEnabled(
+						userData,
+						consultingTypes,
+						settings.disableVideoAppointments
+					),
 				to: '/termine',
 				icon: <CalendarIcon className="navigation__icon" />,
 				titleKeys: {
@@ -501,7 +525,12 @@ export const RouterConfigTeamConsultant = (): any => {
 				component: Profile
 			},
 			{
-				condition: isVideoAppointmentsEnabled,
+				condition: (userData, consultingTypes) =>
+					isVideoAppointmentsEnabled(
+						userData,
+						consultingTypes,
+						settings.disableVideoAppointments
+					),
 				path: '/termine',
 				exact: false,
 				component: Appointments
@@ -529,12 +558,16 @@ export const RouterConfigTeamConsultant = (): any => {
 	};
 };
 
-export const RouterConfigPeerConsultant = (): any => {
-	return RouterConfigConsultant();
+export const RouterConfigPeerConsultant = (
+	settings: AppConfigInterface
+): any => {
+	return RouterConfigConsultant(settings);
 };
 
-export const RouterConfigMainConsultant = (): any => {
-	let config = RouterConfigTeamConsultant();
+export const RouterConfigMainConsultant = (
+	settings: AppConfigInterface
+): any => {
+	const config = RouterConfigTeamConsultant(settings);
 	config.navigation[2].titleKeys = {
 		large: 'navigation.consultant.peersessions',
 		small: 'navigation.consultant.peersessions.small'

--- a/src/components/app/Routing.tsx
+++ b/src/components/app/Routing.tsx
@@ -26,6 +26,7 @@ import { ReleaseNote } from '../releaseNote/ReleaseNote';
 import { NonPlainRoutesWrapper } from './NonPlainRoutesWrapper';
 import { Walkthrough } from '../walkthrough/Walkthrough';
 import { TwoFactorNag } from '../twoFactorAuth/TwoFactorNag';
+import { useAppConfigContext } from '../../globalState/context/useAppConfig';
 
 interface RoutingProps {
 	logout?: Function;
@@ -34,30 +35,31 @@ interface RoutingProps {
 }
 
 export const Routing = (props: RoutingProps) => {
+	const { settings } = useAppConfigContext();
 	const { userData } = useContext(UserDataContext);
 	const { consultingTypes } = useContext(ConsultingTypesContext);
 
 	const routerConfig = useMemo(() => {
 		if (hasUserAuthority(AUTHORITIES.VIEW_ALL_PEER_SESSIONS, userData)) {
-			return RouterConfigMainConsultant();
+			return RouterConfigMainConsultant(settings);
 		}
 		if (hasUserAuthority(AUTHORITIES.USE_FEEDBACK, userData)) {
-			return RouterConfigPeerConsultant();
+			return RouterConfigPeerConsultant(settings);
 		}
 		if (
 			hasUserAuthority(AUTHORITIES.CONSULTANT_DEFAULT, userData) &&
 			userData.inTeamAgency
 		) {
-			return RouterConfigTeamConsultant();
+			return RouterConfigTeamConsultant(settings);
 		}
 		if (hasUserAuthority(AUTHORITIES.CONSULTANT_DEFAULT, userData)) {
-			return RouterConfigConsultant();
+			return RouterConfigConsultant(settings);
 		}
 		if (hasUserAuthority(AUTHORITIES.ANONYMOUS_DEFAULT, userData)) {
 			return RouterConfigAnonymousAsker();
 		}
-		return RouterConfigUser();
-	}, [userData]);
+		return RouterConfigUser(settings);
+	}, [userData, settings]);
 
 	const allRoutes = () =>
 		[

--- a/src/components/consultingTypeSelection/ConsultingTypeAgencySelection.tsx
+++ b/src/components/consultingTypeSelection/ConsultingTypeAgencySelection.tsx
@@ -21,7 +21,7 @@ import {
 } from '../select/SelectDropdown';
 import { Text } from '../text/Text';
 import { AgencyLanguages } from '../agencySelection/AgencyLanguages';
-import { config } from '../../resources/scripts/config';
+import { useAppConfigContext } from '../../globalState/context/useAppConfig';
 
 export interface ConsultingTypeAgencySelectionProps {
 	consultant: ConsultantDataInterface;
@@ -38,6 +38,7 @@ export const useConsultingTypeAgencySelection = (
 	consultingType: ConsultingTypeInterface,
 	agency: AgencyDataInterface
 ) => {
+	const { settings } = useAppConfigContext();
 	const [consultingTypes, setConsultingTypes] = useState<
 		ConsultingTypeInterface[]
 	>([]);
@@ -51,7 +52,7 @@ export const useConsultingTypeAgencySelection = (
 		// When we've the multi tenancy with single domain we can simply ignore the
 		// consulting types because we'll get agencies across tenants
 		if (
-			config.useMultiTenancyWithSingleDomain &&
+			settings.multiTenancyWithSingleDomainEnabled &&
 			consultant?.agencies?.length > 0
 		) {
 			setAgencies(consultant?.agencies);
@@ -99,7 +100,12 @@ export const useConsultingTypeAgencySelection = (
 		}
 
 		setConsultingTypes(consultingTypes);
-	}, [consultant, consultingType, agency]);
+	}, [
+		consultant,
+		consultingType,
+		agency,
+		settings.multiTenancyWithSingleDomainEnabled
+	]);
 
 	return { agencies, consultingTypes };
 };
@@ -113,6 +119,7 @@ export const ConsultingTypeAgencySelection = ({
 	preselectedAgency,
 	onKeyDown
 }: ConsultingTypeAgencySelectionProps) => {
+	const { settings } = useAppConfigContext();
 	const [selectedConsultingTypeOption, setSelectedConsultingTypeOption] =
 		useState<SelectOption>(null);
 	const [consultingTypeOptions, setConsultingTypeOptions] = useState<
@@ -149,7 +156,7 @@ export const ConsultingTypeAgencySelection = ({
 			return;
 		}
 
-		const agencyOptions = config.useMultiTenancyWithSingleDomain
+		const agencyOptions = settings.multiTenancyWithSingleDomainEnabled
 			? possibleAgencies
 			: possibleAgencies.filter(
 					(agency) =>
@@ -161,7 +168,12 @@ export const ConsultingTypeAgencySelection = ({
 		if (agencyOptions.length >= 1) {
 			onChange(agencyOptions[0]);
 		}
-	}, [onChange, possibleAgencies, selectedConsultingTypeOption]);
+	}, [
+		onChange,
+		possibleAgencies,
+		selectedConsultingTypeOption,
+		settings.multiTenancyWithSingleDomainEnabled
+	]);
 
 	useEffect(() => {
 		if (!onValidityChange) {

--- a/src/components/enquiry/EnquiryLanguageSelection.tsx
+++ b/src/components/enquiry/EnquiryLanguageSelection.tsx
@@ -9,6 +9,7 @@ import { isUniqueLanguage } from '../profile/profileHelpers';
 
 import './enquiryLanguageSelection.styles';
 import { FixedLanguagesContext } from '../../globalState/provider/FixedLanguagesProvider';
+import { useAppConfigContext } from '../../globalState/context/useAppConfig';
 
 interface EnquiryLanguageSelectionProps {
 	className?: string;
@@ -17,6 +18,7 @@ interface EnquiryLanguageSelectionProps {
 
 export const EnquiryLanguageSelection: React.FC<EnquiryLanguageSelectionProps> =
 	({ className = '', handleSelection }) => {
+		const { settings } = useAppConfigContext();
 		const { sessions, ready } = useContext(SessionsDataContext);
 		const fixedLanguages = useContext(FixedLanguagesContext);
 		const { sessionId: sessionIdFromParam } = useParams();
@@ -49,11 +51,12 @@ export const EnquiryLanguageSelection: React.FC<EnquiryLanguageSelectionProps> =
 					return;
 				}
 
-				const response = await apiAgencyLanguages(agencyId).catch(
-					() => {
-						/* intentional, falls back to fixed languages */
-					}
-				);
+				const response = await apiAgencyLanguages(
+					agencyId,
+					settings?.multiTenancyWithSingleDomainEnabled
+				).catch(() => {
+					/* intentional, falls back to fixed languages */
+				});
 
 				if (!response) {
 					return;
@@ -75,7 +78,13 @@ export const EnquiryLanguageSelection: React.FC<EnquiryLanguageSelectionProps> =
 			};
 
 			getLanguagesFromApi();
-		}, [sessions, ready, sessionIdFromParam, fixedLanguages]);
+		}, [
+			sessions,
+			ready,
+			sessionIdFromParam,
+			fixedLanguages,
+			settings?.multiTenancyWithSingleDomainEnabled
+		]);
 
 		const selectLanguage = (isoCode) => {
 			setSelectedLanguage(isoCode);

--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -59,6 +59,7 @@ import { TwoFactorAuthResendMail } from '../twoFactorAuth/TwoFactorAuthResendMai
 import { RocketChatGlobalSettingsContext } from '../../globalState';
 import { SETTING_E2E_ENABLE } from '../../api/apiRocketChatSettingsPublic';
 import { ensureTenantSettings } from '../../utils/tenantHelpers';
+import { useAppConfigContext } from '../../globalState/context/useAppConfig';
 
 const loginButton: ButtonItem = {
 	label: translate('login.button.label'),
@@ -73,6 +74,7 @@ interface LoginProps {
 export const Login = ({ legalLinks, stageComponent: Stage }: LoginProps) => {
 	const { tenant } = useContext(TenantContext);
 	const { getSetting } = useContext(RocketChatGlobalSettingsContext);
+	const { settings } = useAppConfigContext();
 
 	const hasTenant = tenant != null;
 
@@ -306,7 +308,8 @@ export const Login = ({ legalLinks, stageComponent: Stage }: LoginProps) => {
 			username: username,
 			password: password,
 			redirect: !consultant,
-			...ensureTenantSettings(tenant?.settings)
+			...ensureTenantSettings(tenant?.settings, settings.budibaseSSO),
+			enableBudibaseSSO: settings.budibaseSSO
 		})
 			.then(postLogin)
 			.catch((error) => {
@@ -341,7 +344,8 @@ export const Login = ({ legalLinks, stageComponent: Stage }: LoginProps) => {
 				password,
 				redirect: !consultant,
 				otp,
-				...ensureTenantSettings(tenant?.settings)
+				enableBudibaseSSO: settings.budibaseSSO,
+				...ensureTenantSettings(tenant?.settings, settings.budibaseSSO)
 			})
 				.then(postLogin)
 				.catch((error) => {

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -46,6 +46,7 @@ import {
 	SingleComponentType,
 	TabGroups
 } from '../../utils/tabsHelper';
+import { useAppConfigContext } from '../../globalState/context/useAppConfig';
 
 interface ProfileProps {
 	legalLinks: Array<LegalLinkInterface>;
@@ -53,6 +54,7 @@ interface ProfileProps {
 }
 
 export const Profile = (props: ProfileProps) => {
+	const { settings } = useAppConfigContext();
 	const location = useLocation();
 	const consultingTypes = useConsultingTypes();
 	const { fromL } = useResponsive();
@@ -79,7 +81,7 @@ export const Profile = (props: ProfileProps) => {
 
 	useEffect(() => {
 		setMobileMenu(
-			profileRoutes
+			profileRoutes(settings)
 				.filter((tab) =>
 					solveTabConditions(tab, userData, consultingTypes)
 				)
@@ -119,7 +121,7 @@ export const Profile = (props: ProfileProps) => {
 					})
 				)
 		);
-	}, [consultingTypes, props.spokenLanguages, userData]);
+	}, [consultingTypes, props.spokenLanguages, settings, userData]);
 
 	const [subpage, setSubpage] = useState(undefined);
 	useEffect(() => {
@@ -187,7 +189,7 @@ export const Profile = (props: ProfileProps) => {
 					</div>
 					<div className="profile__nav flex flex__col--grow flex__col--shrink flex--jc-c flex--ai-s flex__col--50p">
 						{fromL ? (
-							profileRoutes
+							profileRoutes(settings)
 								.filter((tab) =>
 									solveTabConditions(
 										tab,
@@ -231,7 +233,7 @@ export const Profile = (props: ProfileProps) => {
 					<Switch>
 						{fromL ? (
 							// Render tabs for desktop
-							profileRoutes
+							profileRoutes(settings)
 								.filter((tab) =>
 									solveTabConditions(
 										tab,
@@ -286,7 +288,7 @@ export const Profile = (props: ProfileProps) => {
 						) : (
 							// Render submenu for mobile
 							<Route
-								path={profileRoutes
+								path={profileRoutes(settings)
 									.filter((tab) =>
 										solveTabConditions(
 											tab,
@@ -305,7 +307,7 @@ export const Profile = (props: ProfileProps) => {
 
 						{!fromL &&
 							// Render groups as routes for mobile
-							profileRoutes
+							profileRoutes(settings)
 								.filter((tab) =>
 									solveTabConditions(
 										tab,
@@ -353,7 +355,9 @@ export const Profile = (props: ProfileProps) => {
 										);
 								})}
 
-						<Redirect to={`/profile${profileRoutes[0].url}`} />
+						<Redirect
+							to={`/profile${profileRoutes(settings)[0].url}`}
+						/>
 					</Switch>
 				</div>
 

--- a/src/components/profile/profile.routes.ts
+++ b/src/components/profile/profile.routes.ts
@@ -1,4 +1,8 @@
-import { AUTHORITIES, hasUserAuthority } from '../../globalState';
+import {
+	AppConfigInterface,
+	AUTHORITIES,
+	hasUserAuthority
+} from '../../globalState';
 import { translate } from '../../utils/translate';
 import { ConsultantInformation } from './ConsultantInformation';
 import { ConsultantSpokenLanguages } from './ConsultantSpokenLanguages';
@@ -14,12 +18,11 @@ import { PasswordReset } from '../passwordReset/PasswordReset';
 import { TwoFactorAuth } from '../twoFactorAuth/TwoFactorAuth';
 import { DeleteAccount } from './DeleteAccount';
 import { EnableWalkthrough } from './EnableWalkthrough';
-import { config } from '../../resources/scripts/config';
 import { Help } from '../help/Help';
 import { ConsultantNotifications } from './ConsultantNotifications';
 import { COLUMN_LEFT, COLUMN_RIGHT, TabsType } from '../../utils/tabsHelper';
 
-const routes: TabsType = [
+export const routes = (settings: AppConfigInterface): TabsType => [
 	{
 		title: translate('profile.routes.general'),
 		url: '/allgemeines',
@@ -60,7 +63,7 @@ const routes: TabsType = [
 							hasUserAuthority(
 								AUTHORITIES.CONSULTANT_DEFAULT,
 								userData
-							) && config.enableWalkthrough,
+							) && settings.enableWalkThrough,
 						component: EnableWalkthrough,
 						column: COLUMN_LEFT
 					},

--- a/src/components/registration/RegistrationForm.tsx
+++ b/src/components/registration/RegistrationForm.tsx
@@ -38,6 +38,7 @@ import {
 	redirectToErrorPage
 } from '../error/errorHandling';
 import { TopicsDataInterface } from '../../globalState/interfaces/TopicsDataInterface';
+import { useAppConfigContext } from '../../globalState/context/useAppConfig';
 
 interface RegistrationFormProps {
 	consultingType?: ConsultingTypeInterface;
@@ -67,6 +68,7 @@ export const RegistrationForm = ({
 	consultant
 }: RegistrationFormProps) => {
 	const tenantData = useTenant();
+	const { settings } = useAppConfigContext();
 	const [formAccordionData, setFormAccordionData] =
 		useState<FormAccordionData>({});
 	const [formAccordionValid, setFormAccordionValid] = useState(false);
@@ -215,6 +217,8 @@ export const RegistrationForm = ({
 		apiPostRegistration(
 			config.endpoints.registerAsker,
 			registrationData,
+			settings.multiTenancyWithSingleDomainEnabled,
+			settings.budibaseSSO,
 			tenant
 		)
 			.then((res) => {

--- a/src/components/registration/autoLogin.ts
+++ b/src/components/registration/autoLogin.ts
@@ -48,6 +48,7 @@ interface AutoLoginProps {
 	otp?: string;
 	useOldUser?: boolean;
 	tenantSettings?: TenantDataSettingsInterface;
+	enableBudibaseSSO: boolean;
 }
 
 export const autoLogin = (autoLoginProps: AutoLoginProps): Promise<any> =>
@@ -102,7 +103,7 @@ export const autoLogin = (autoLoginProps: AutoLoginProps): Promise<any> =>
 						reject(error);
 					});
 
-				if (config.budibaseSSO) {
+				if (autoLoginProps.enableBudibaseSSO) {
 					getBudibaseAccessToken(
 						username,
 						autoLoginProps.password,
@@ -121,7 +122,11 @@ export const autoLogin = (autoLoginProps: AutoLoginProps): Promise<any> =>
 						redirect: autoLoginProps.redirect,
 						otp: autoLoginProps.otp,
 						useOldUser: true,
-						...ensureTenantSettings(autoLoginProps?.tenantSettings)
+						enableBudibaseSSO: autoLoginProps.enableBudibaseSSO,
+						...ensureTenantSettings(
+							autoLoginProps?.tenantSettings,
+							autoLoginProps.enableBudibaseSSO
+						)
 					})
 						.then(() => resolve(undefined))
 						.catch((autoLoginError) => reject(autoLoginError));

--- a/src/components/walkthrough/Walkthrough.tsx
+++ b/src/components/walkthrough/Walkthrough.tsx
@@ -8,12 +8,12 @@ import './walkthrough.styles.scss';
 import { translate } from '../../utils/translate';
 import { UserDataContext } from '../../globalState';
 import { apiPatchConsultantData } from '../../api';
-import { config } from '../../resources/scripts/config';
-
 import steps from './steps';
+import { useAppConfigContext } from '../../globalState/context/useAppConfig';
 
 export const Walkthrough = () => {
 	const ref = useRef<any>();
+	const { settings } = useAppConfigContext();
 	const { userData, setUserData } = useContext(UserDataContext);
 	const history = useHistory();
 
@@ -39,7 +39,7 @@ export const Walkthrough = () => {
 			ref={ref}
 			enabled={
 				userData.isWalkThroughEnabled &&
-				config.enableWalkthrough &&
+				settings.enableWalkThrough &&
 				!userData.twoFactorAuth.isShown
 			}
 			onExit={() => {

--- a/src/globalState/context/useAppConfig.tsx
+++ b/src/globalState/context/useAppConfig.tsx
@@ -1,0 +1,78 @@
+import React, { useCallback } from 'react';
+import { config } from '../../resources/scripts/config';
+import { AppConfigInterface } from '../interfaces/AppConfigInterface';
+import { ServerAppConfigInterface } from '../interfaces/ServerAppConfigInterface';
+
+interface AppConfigContextInterface {
+	settings: AppConfigInterface;
+	setServerSettings: (settings: ServerAppConfigInterface) => void;
+	setManualSettings: (settings: Partial<AppConfigInterface>) => void;
+}
+
+const UseAppConfigContext =
+	React.createContext<
+		[
+			AppConfigInterface,
+			React.Dispatch<React.SetStateAction<AppConfigInterface>>
+		]
+	>(null);
+
+const UseAppConfigProvider = ({
+	children
+}: {
+	children?: React.ReactChild | React.ReactChild[];
+}) => {
+	const state = React.useState<AppConfigInterface>({
+		budibaseSSO: config.budibaseSSO,
+		enableTenantTheming: config.enableTenantTheming,
+		enableWalkThrough: config.enableWalkthrough,
+		disableVideoAppointments: config.disableVideoAppointments,
+		multiTenancyWithSingleDomainEnabled:
+			config.useMultiTenancyWithSingleDomain,
+		useTenantService: config.useTenantService,
+		useApiClusterSettings: config.useApiClusterSettings
+	});
+	return (
+		<UseAppConfigContext.Provider value={state}>
+			{' '}
+			{children}{' '}
+		</UseAppConfigContext.Provider>
+	);
+};
+
+const useAppConfigContext = (): AppConfigContextInterface => {
+	const [settings, setNewSettings] = React.useContext(UseAppConfigContext);
+
+	const setServerSettings = useCallback(
+		(serverSettings: ServerAppConfigInterface) => {
+			const finalServerSettings = Object.keys(serverSettings).reduce(
+				(current, key) => ({
+					...current,
+					[key]: serverSettings[key].value
+				}),
+				{} as Record<string, boolean>
+			);
+			setNewSettings({
+				...settings,
+				...(finalServerSettings as unknown as AppConfigInterface)
+			});
+			console.log({ ...settings, ...finalServerSettings });
+		},
+		[setNewSettings, settings]
+	);
+
+	const setManualSettings = useCallback(
+		(newSettings: Partial<AppConfigInterface>) => {
+			setNewSettings({ ...settings, ...newSettings });
+		},
+		[settings, setNewSettings]
+	);
+
+	return {
+		setServerSettings,
+		settings,
+		setManualSettings
+	};
+};
+
+export { UseAppConfigProvider, useAppConfigContext };

--- a/src/globalState/context/useAppConfig.tsx
+++ b/src/globalState/context/useAppConfig.tsx
@@ -56,7 +56,6 @@ const useAppConfigContext = (): AppConfigContextInterface => {
 				...settings,
 				...(finalServerSettings as unknown as AppConfigInterface)
 			});
-			console.log({ ...settings, ...finalServerSettings });
 		},
 		[setNewSettings, settings]
 	);

--- a/src/globalState/index.ts
+++ b/src/globalState/index.ts
@@ -5,6 +5,8 @@ export * from './interfaces/SessionsDataInterface';
 export * from './interfaces/UserDataInterface';
 export * from './interfaces/ConsultingTypeInterface';
 export * from './interfaces/LegalLinkInterface';
+export * from './interfaces/AppConfigInterface';
+export * from './interfaces/ServerAppConfigInterface';
 
 export * from './provider/AnonymousConversationFinishedProvider';
 export * from './provider/AnonymousEnquiryAcceptedProvider';
@@ -21,3 +23,4 @@ export * from './provider/WebsocketConnectionDeactivatedProvider';
 export * from './provider/TenantProvider';
 export * from './provider/RocketChatProvider';
 export * from './provider/RocketChatGlobalSettingsProvider';
+export * from './context/useAppConfig';

--- a/src/globalState/interfaces/AppConfigInterface.ts
+++ b/src/globalState/interfaces/AppConfigInterface.ts
@@ -1,0 +1,16 @@
+export interface AppConfigInterface {
+	/** Feature flag to enable SSO on budibase */
+	budibaseSSO: boolean; //
+	/** Feature flag to enable tenant theming based on subdomains */
+	enableTenantTheming: boolean;
+	/** Feature flag to enable walkthrough (false by default here & true in the theme repo) */
+	enableWalkThrough: boolean;
+	/** Feature flag to enable Video-Termine page */
+	disableVideoAppointments: boolean;
+	/** Feature flag to enable the multi tenancy with a single domain ex: lands */
+	multiTenancyWithSingleDomainEnabled: boolean;
+	/** Feature flag to enable request to retrieve settings from the tenant service */
+	useTenantService: boolean;
+	/** Feature flag to enable cluster settings from the api instead of the config file */
+	useApiClusterSettings: boolean;
+}

--- a/src/globalState/interfaces/AppConfigInterface.ts
+++ b/src/globalState/interfaces/AppConfigInterface.ts
@@ -13,4 +13,6 @@ export interface AppConfigInterface {
 	useTenantService: boolean;
 	/** Feature flag to enable cluster settings from the api instead of the config file */
 	useApiClusterSettings: boolean;
+	/** When the Feature flag multiTenancyWithSingleDomainEnabled is used we need to know the main subdomain */
+	mainTenantSubdomainForSingleDomainMultitenancy?: string;
 }

--- a/src/globalState/interfaces/ServerAppConfigInterface.ts
+++ b/src/globalState/interfaces/ServerAppConfigInterface.ts
@@ -1,0 +1,8 @@
+export interface ServerAppConfigInterface {
+	[key: string]: ServerAppConfigValueInterface;
+}
+
+interface ServerAppConfigValueInterface {
+	value: boolean;
+	readOnly: boolean;
+}

--- a/src/globalState/interfaces/ServerAppConfigInterface.ts
+++ b/src/globalState/interfaces/ServerAppConfigInterface.ts
@@ -1,8 +1,12 @@
-export interface ServerAppConfigInterface {
+export type ServerAppConfigInterface = {
 	[key: string]: ServerAppConfigValueInterface;
+} & ServerAppConfigCustomInterface;
+
+interface ServerAppConfigCustomInterface {
+	mainTenantSubdomainForSingleDomainMultitenancy?: ServerAppConfigValueInterface<string>;
 }
 
-interface ServerAppConfigValueInterface {
-	value: boolean;
+interface ServerAppConfigValueInterface<T = boolean> {
+	value: T;
 	readOnly: boolean;
 }

--- a/src/globalState/state.tsx
+++ b/src/globalState/state.tsx
@@ -11,7 +11,8 @@ import {
 	TenantProvider,
 	RocketChatGlobalSettingsProvider,
 	AnonymousConversationStartedProvider,
-	SessionsDataProvider
+	SessionsDataProvider,
+	UseAppConfigProvider
 } from '.';
 
 function ProviderComposer({ contexts, children }) {
@@ -39,7 +40,8 @@ function ContextProvider({ children }) {
 				<WebsocketConnectionDeactivatedProvider />,
 				<TenantProvider />,
 				<SessionsDataProvider />,
-				<RocketChatGlobalSettingsProvider />
+				<RocketChatGlobalSettingsProvider />,
+				<UseAppConfigProvider />
 			]}
 		>
 			{children}

--- a/src/initError.tsx
+++ b/src/initError.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Error } from './components/error/Error';
+import { UseAppConfigProvider } from './globalState/context/useAppConfig';
 
-ReactDOM.render(<Error />, document.getElementById('errorRoot'));
+ReactDOM.render(
+	<UseAppConfigProvider>
+		<Error />
+	</UseAppConfigProvider>,
+	document.getElementById('errorRoot')
+);

--- a/src/resources/scripts/config.ts
+++ b/src/resources/scripts/config.ts
@@ -21,6 +21,7 @@ export const config = {
 	disableVideoAppointments: false, // Feature flag to enable Video-Termine page
 	useMultiTenancyWithSingleDomain: false, // Feature flag to enable the multi tenancy with a single domain ex: lands
 	useTenantService: false,
+	useApiClusterSettings: true, // Feature flag to enable the cluster use the cluster settings instead of the config file
 
 	endpoints: {
 		agencyConsultants: apiUrl + '/service/users/consultants',
@@ -139,6 +140,7 @@ export const config = {
 		updateMonitoring: apiUrl + '/service/users/sessions/monitoring',
 		userData: apiUrl + '/service/users/data',
 		userSessionsListView: '/sessions/user/view',
+		serviceSettings: apiUrl + '/service/settings',
 		setAppointmentSuccessMessage:
 			apiUrl + '/service/messages/aliasWithContent/new',
 		userUpdateE2EKey: apiUrl + '/service/users/chat/e2e',

--- a/src/resources/scripts/config.ts
+++ b/src/resources/scripts/config.ts
@@ -22,6 +22,7 @@ export const config = {
 	useMultiTenancyWithSingleDomain: false, // Feature flag to enable the multi tenancy with a single domain ex: lands
 	useTenantService: false,
 	useApiClusterSettings: true, // Feature flag to enable the cluster use the cluster settings instead of the config file
+	mainTenantSubdomainForSingleDomainMultitenancy: 'app',
 
 	endpoints: {
 		agencyConsultants: apiUrl + '/service/users/consultants',

--- a/src/resources/scripts/config.ts
+++ b/src/resources/scripts/config.ts
@@ -21,7 +21,7 @@ export const config = {
 	disableVideoAppointments: false, // Feature flag to enable Video-Termine page
 	useMultiTenancyWithSingleDomain: false, // Feature flag to enable the multi tenancy with a single domain ex: lands
 	useTenantService: false,
-	useApiClusterSettings: true, // Feature flag to enable the cluster use the cluster settings instead of the config file
+	useApiClusterSettings: false, // Feature flag to enable the cluster use the cluster settings instead of the config file
 	mainTenantSubdomainForSingleDomainMultitenancy: 'app',
 
 	endpoints: {

--- a/src/utils/tenantHelpers.ts
+++ b/src/utils/tenantHelpers.ts
@@ -1,10 +1,10 @@
 import { TenantDataSettingsInterface } from '../globalState/interfaces/TenantDataInterface';
-import { config } from '../resources/scripts/config';
 
 export const ensureTenantSettings = (
-	tenantSettings: TenantDataSettingsInterface
+	tenantSettings: TenantDataSettingsInterface,
+	enableBudibaseSSO: boolean
 ) => {
-	return config.budibaseSSO
+	return enableBudibaseSSO
 		? {
 				tenantSettings
 		  }

--- a/src/utils/useTenantTheming.ts
+++ b/src/utils/useTenantTheming.ts
@@ -6,6 +6,7 @@ import { config } from '../resources/scripts/config';
 import getLocationVariables from './getLocationVariables';
 import decodeHTML from './decodeHTML';
 import contrast from 'get-contrast';
+import { useAppConfigContext } from '../globalState/context/useAppConfig';
 
 const RGBToHSL = (r, g, b) => {
 	// Make r, g, and b fractions of 1
@@ -217,6 +218,7 @@ const applyTheming = (tenant: TenantDataInterface) => {
 };
 
 const useTenantTheming = () => {
+	const { settings } = useAppConfigContext();
 	const tenantContext = useContext(TenantContext);
 	const { subdomain } = getLocationVariables();
 	const [isLoadingTenant, setIsLoadingTenant] = useState(
@@ -224,20 +226,28 @@ const useTenantTheming = () => {
 	);
 
 	useEffect(() => {
-		if (!config.useTenantService) {
+		if (!settings.useTenantService) {
 			setIsLoadingTenant(false);
 			return;
 		}
 
-		if (!subdomain || !config.enableTenantTheming) {
-			apiGetTenantTheming({ subdomain }).then(({ settings }) => {
+		if (!subdomain || !settings.enableTenantTheming) {
+			apiGetTenantTheming({
+				subdomain,
+				useMultiTenancyWithSingleDomain:
+					settings?.multiTenancyWithSingleDomainEnabled
+			}).then(({ settings }) => {
 				tenantContext?.setTenant({ settings } as any);
 				setIsLoadingTenant(false);
 			});
 			return;
 		}
 
-		apiGetTenantTheming({ subdomain })
+		apiGetTenantTheming({
+			subdomain,
+			useMultiTenancyWithSingleDomain:
+				settings?.multiTenancyWithSingleDomainEnabled
+		})
 			.then((tenant) => {
 				// ToDo: See VIC-428 + VIC-427
 				const decodedTenant = JSON.parse(JSON.stringify(tenant));

--- a/src/utils/useTenantTheming.ts
+++ b/src/utils/useTenantTheming.ts
@@ -235,7 +235,9 @@ const useTenantTheming = () => {
 			apiGetTenantTheming({
 				subdomain,
 				useMultiTenancyWithSingleDomain:
-					settings?.multiTenancyWithSingleDomainEnabled
+					settings?.multiTenancyWithSingleDomainEnabled,
+				mainTenantSubdomainForSingleDomain:
+					settings.mainTenantSubdomainForSingleDomainMultitenancy
 			}).then(({ settings }) => {
 				tenantContext?.setTenant({ settings } as any);
 				setIsLoadingTenant(false);
@@ -246,7 +248,9 @@ const useTenantTheming = () => {
 		apiGetTenantTheming({
 			subdomain,
 			useMultiTenancyWithSingleDomain:
-				settings?.multiTenancyWithSingleDomainEnabled
+				settings?.multiTenancyWithSingleDomainEnabled,
+			mainTenantSubdomainForSingleDomain:
+				settings.mainTenantSubdomainForSingleDomainMultitenancy
 		})
 			.then((tenant) => {
 				// ToDo: See VIC-428 + VIC-427

--- a/src/utils/useUrlParamsLoader.tsx
+++ b/src/utils/useUrlParamsLoader.tsx
@@ -12,8 +12,10 @@ import { isNumber } from './isNumber';
 import { config } from '../resources/scripts/config';
 import { TopicsDataInterface } from '../globalState/interfaces/TopicsDataInterface';
 import { apiGetTopicById } from '../api/apiGetTopicId';
+import { useAppConfigContext } from '../globalState/context/useAppConfig';
 
 export default function useUrlParamsLoader() {
+	const { settings } = useAppConfigContext();
 	const { consultingTypeSlug } = useParams();
 	const agencyId = getUrlParameter('aid');
 	const consultantId = getUrlParameter('cid');
@@ -59,7 +61,7 @@ export default function useUrlParamsLoader() {
 				}
 				// When we've the multi tenancy with single domain enabled we'll always have multiple consulting types
 				if (
-					!config.useMultiTenancyWithSingleDomain &&
+					!settings.multiTenancyWithSingleDomainEnabled &&
 					agency?.consultingType !== consultingType?.id
 				) {
 					agency = null;


### PR DESCRIPTION
## Proposed Changes

  - Adding the new way of having the app settings in an api instead of having static in the config file
  - This is protected by a feature flag called **useApiClusterSettings** so if this is enabled then we use the api settings otherwise we use the settings from the config file.
  - By default even with the flag **useApiClusterSettings** enabled we still apply the defaults from the config file
  - **Breaking change**: From now on when we want to check something regarding settings we need to use the hook **useAppConfigContext** this handles all the settings.
  - The new hook is prepared to adapt to new cluster toggles, that means that we just need to add the new key to the interface called **AppConfigInterface** and that's it, if you need some default value is also needed to set the default value in the function **UseAppConfigProvider**
