### PR TITLE
fix: issue when is a new AS is registered

### DIFF
--- a/src/globalState/provider/RocketChatUsersOfRoomProvider.tsx
+++ b/src/globalState/provider/RocketChatUsersOfRoomProvider.tsx
@@ -61,12 +61,14 @@ export const RocketChatUsersOfRoomProvider = ({
 			load().then(() => {
 				setReady(true);
 			});
+		} else if (!activeSession?.rid && activeSession.isEmptyEnquiry) {
+			setReady(true);
 		}
 
 		return () => {
 			setReady(false);
 		};
-	}, [activeSession?.rid, socketReady, load]);
+	}, [activeSession?.rid, socketReady, load, activeSession.isEmptyEnquiry]);
 
 	if (!ready) {
 		return null;


### PR DESCRIPTION
Fixes #
When an new AS is registered he doesn't have the rocket chat id until he first writes a new message

![image](https://user-images.githubusercontent.com/1266477/215990843-a1181d56-24b0-4d24-9a60-f546b5e42a1f.png)
