### PR TITLE
fix: german informal language

### DIFF
--- a/src/globalState/provider/LocaleProvider.tsx
+++ b/src/globalState/provider/LocaleProvider.tsx
@@ -39,6 +39,7 @@ export function LocaleProvider(props) {
 			...settings.i18n,
 			...(tenant?.settings?.activeLanguages && {
 				supportedLngs: [
+					'de_informal',
 					...(tenant?.settings?.activeLanguages || []),
 					// If tenant service has 'de' active add default supported languages 'de' and 'de_informal'
 					// If 'de' is deactivated 'de_informal' should not be available too


### PR DESCRIPTION
Fixes #
When we use the admin console to set the available languages we only set the de and we miss the de_informal, so with this change it will add support to it
